### PR TITLE
Use runner's CodeQL instead of downloading `gh-codeql`

### DIFF
--- a/.github/scripts/pr-compile.sh
+++ b/.github/scripts/pr-compile.sh
@@ -7,7 +7,7 @@ LANGUAGE=${2}
 LIBRARY_SCANNED=false
 
 echo "[+] Compiling all queries in $LANGUAGE"
-gh codeql query compile --threads=0 --check-only "./$LANGUAGE/"
+codeql query compile --threads=0 --check-only "./$LANGUAGE/"
 
 for file in $(gh pr view "$PR_NUMBER" --json files --jq '.files.[].path'); do
     if [[ ! -f "$file" ]]; then
@@ -19,12 +19,12 @@ for file in $(gh pr view "$PR_NUMBER" --json files --jq '.files.[].path'); do
         echo "[+] Compiling $file (in $LANGUAGE)"
 
         # compile the query
-        gh codeql query compile --threads=0 --check-only --warnings=error "./$file"
+        codeql query compile --threads=0 --check-only --warnings=error "./$file"
 
     # if lib folder is modified
     elif [[ "$file" == $LANGUAGE/lib/* ]] && [[ $LIBRARY_SCANNED == false ]]; then
         echo "[+] Libray changed, compiling all queries in $LANGUAGE"
-        gh codeql query compile --threads=0 --check-only --warnings=error "./$LANGUAGE/"
+        codeql query compile --threads=0 --check-only --warnings=error "./$LANGUAGE/"
         # set LIBRARY_SCANNED to true to prevent recompiling
         LIBRARY_SCANNED=true
 

--- a/.github/scripts/pr-suites-packs.sh
+++ b/.github/scripts/pr-suites-packs.sh
@@ -13,7 +13,7 @@ for file in $(gh pr view "$PR_NUMBER" --json files --jq '.files.[].path'); do
     # suite folder 
     if [[ "$file" == $LANGUAGE/suites/**.qls ]]; then
         echo "[+] Compiling Suite: $file"
-        gh codeql resolve queries "$file"
+        codeql resolve queries "$file"
 
     # qlpack file and lock file
     elif [[ "$file" == $LANGUAGE/qlpack.yml ]] || [[ "$file" == $LANGUAGE/codeql-pack.lock.yml ]]; then
@@ -22,18 +22,18 @@ for file in $(gh pr view "$PR_NUMBER" --json files --jq '.files.[].path'); do
         fi 
         echo "[+] Compiling Pack: $LANGUAGE"
         # install deps
-        gh codeql pack install "$LANGUAGE"
+        codeql pack install "$LANGUAGE"
         # compile / create pack
-        gh codeql pack create "$LANGUAGE"
+        codeql pack create "$LANGUAGE"
 
         # if the version of the pack is changed, comment in the PR
-        PUBLISHED_VERSION=$(gh api /orgs/advanced-security/packages/container/codeql-"$LANGUAGE"/versions --jq '.[0].metadata.container.tags[0]')
+        PUBLISHED_VERSION=$(gh api /orgs/githubsecuritylab/packages/container/codeql-"$LANGUAGE"/versions --jq '.[0].metadata.container.tags[0]')
         CURRENT_VERSION=$(grep version "$LANGUAGE"/qlpack.yml | awk '{print $2}')
 
         if [ "$PUBLISHED_VERSION" != "$CURRENT_VERSION" ]; then
             echo "[+] New version of pack detected: $PUBLISHED_VERSION (pub) != $CURRENT_VERSION (cur)"
 
-            comment="New version of pack \`advanced-security/codeql-$LANGUAGE\` will be created on merge: \`$PUBLISHED_VERSION\`->\`$CURRENT_VERSION\`"
+            comment="New version of pack \`githubsecuritylab/codeql-$LANGUAGE\` will be created on merge: \`$PUBLISHED_VERSION\`->\`$CURRENT_VERSION\`"
 
             if [[ ! $(gh pr view "$PR_NUMBER" --json comments --jq '.comments.[].body' | grep "$comment") ]]; then
                 echo "[+] Commenting on PR"

--- a/.github/scripts/pr-tests.sh
+++ b/.github/scripts/pr-tests.sh
@@ -10,7 +10,7 @@ if [[ ! -d ./${LANGUAGE}/test/ ]]; then
 fi
 
 echo "[+] Compiling all queries in $LANGUAGE"
-gh codeql query compile --threads=0 --check-only "./$LANGUAGE/"
+codeql query compile --threads=0 --check-only "./$LANGUAGE/"
 
 for file in $(gh pr view "$PR_NUMBER" --json files --jq '.files.[].path'); do
     if [[ ! -f "$file" ]]; then
@@ -22,7 +22,7 @@ for file in $(gh pr view "$PR_NUMBER" --json files --jq '.files.[].path'); do
         echo "[+] Test $file changed"
         TEST_DIR=$(dirname "$file")
         # run tests in the folder the change occured in
-        gh codeql test run "$TEST_DIR"
+        codeql test run "$TEST_DIR"
             
     # if the files is a query file .ql or .qll
     elif [[ "$file" == $LANGUAGE/**.ql ]] || [[ "$file" == $LANGUAGE/**.qll ]] ; then
@@ -33,7 +33,7 @@ for file in $(gh pr view "$PR_NUMBER" --json files --jq '.files.[].path'); do
         
         if [[ -d "$TEST_DIR" ]]; then
             echo "[+] Running tests for $file -> $TEST_DIR"
-            gh codeql test run "$TEST_DIR"
+            codeql test run "$TEST_DIR"
 
         else
             echo "[!] No tests found at $TEST_DIR"
@@ -45,7 +45,7 @@ for file in $(gh pr view "$PR_NUMBER" --json files --jq '.files.[].path'); do
 
         if [[ -d "$TEST_DIR" ]]; then
             echo "[+] Running tests for $file -> $TEST_DIR"
-            gh codeql test run "$TEST_DIR"
+            codeql test run "$TEST_DIR"
         else
             echo "[!] No tests found for $file (in $LANGUAGE)"
         fi

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -28,16 +28,24 @@ jobs:
             src:
               - '${{ matrix.language }}/**'
 
-      - name: Install CodeQL
+      - name: Initialize CodeQL
+        if: steps.changes.outputs.src == 'true'
+        run: |
+          VERSION="$(find "${{ runner.tool_cache }}/CodeQL/" -maxdepth 1 -mindepth 1 -type d -print \
+                       | sort \
+                       | tail -n 1 \
+                       | tr -d '\n')"
+          echo "$VERSION/x64/codeql" >> $GITHUB_PATH
+        
+      - name: Install Packs
         if: steps.changes.outputs.src == 'true'
         env:
           GITHUB_TOKEN: ${{ github.token }}
         run: |
-          gh extension install github/gh-codeql
-          gh codeql pack download "codeql/${{ matrix.language }}-queries"
-          gh codeql pack install "${{ matrix.language }}/lib"
-          gh codeql pack install "${{ matrix.language }}/src"
-          gh codeql pack install "${{ matrix.language }}/test"
+          codeql pack download "codeql/${{ matrix.language }}-queries"
+          codeql pack install "${{ matrix.language }}/lib"
+          codeql pack install "${{ matrix.language }}/src"
+          codeql pack install "${{ matrix.language }}/test"
 
       - name: Compile Queries
         if: steps.changes.outputs.src == 'true'
@@ -81,14 +89,22 @@ jobs:
             src:
               - '${{ matrix.language }}/ext/**'
 
-      - name: Install CodeQL
+      - name: Initialize CodeQL
+        if: steps.changes.outputs.src == 'true'
+        run: |
+          VERSION="$(find "${{ runner.tool_cache }}/CodeQL/" -maxdepth 1 -mindepth 1 -type d -print \
+                       | sort \
+                       | tail -n 1 \
+                       | tr -d '\n')"
+          echo "$VERSION/x64/codeql" >> $GITHUB_PATH
+
+      - name: Install Packs
         if: steps.changes.outputs.src == 'true'
         env:
           GITHUB_TOKEN: ${{ github.token }}
         run: |
-          gh extension install github/gh-codeql
-          gh codeql pack install "${{ matrix.language }}/ext/"
-          gh codeql pack install "${{ matrix.language }}/ext-library-sources/"
-          gh codeql pack create "${{ matrix.language }}/ext/"
-          gh codeql pack create "${{ matrix.language }}/ext-library-sources/"
+          codeql pack install "${{ matrix.language }}/ext/"
+          codeql pack install "${{ matrix.language }}/ext-library-sources/"
+          codeql pack create "${{ matrix.language }}/ext/"
+          codeql pack create "${{ matrix.language }}/ext-library-sources/"
 

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -22,6 +22,14 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
+      - name: Initialize CodeQL
+        run: |
+          VERSION="$(find "${{ runner.tool_cache }}/CodeQL/" -maxdepth 1 -mindepth 1 -type d -print \
+                       | sort \
+                       | tail -n 1 \
+                       | tr -d '\n')"
+          echo "$VERSION/x64/codeql" >> $GITHUB_PATH
+
       - name: "Check and publish codeql-LANG-queries (src) pack"
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -30,9 +38,8 @@ jobs:
           CURRENT_VERSION=$(grep version ${{ matrix.language }}/src/qlpack.yml | awk '{print $2}')
 
           if [ "$PUBLISHED_VERSION" != "$CURRENT_VERSION" ]; then
-            gh extension install github/gh-codeql
-            gh codeql pack install "${{ matrix.language }}/src"
-            gh codeql pack publish "${{ matrix.language }}/src"
+            codeql pack install "${{ matrix.language }}/src"
+            codeql pack publish "${{ matrix.language }}/src"
           fi
 
   library:
@@ -50,6 +57,14 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
+      - name: Initialize CodeQL
+        run: |
+          VERSION="$(find "${{ runner.tool_cache }}/CodeQL/" -maxdepth 1 -mindepth 1 -type d -print \
+                       | sort \
+                       | tail -n 1 \
+                       | tr -d '\n')"
+          echo "$VERSION/x64/codeql" >> $GITHUB_PATH
+
       - name: "Check and publish codeql-LANG-libs (lib) pack"
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -58,9 +73,8 @@ jobs:
           CURRENT_VERSION=$(grep version ${{ matrix.language }}/lib/qlpack.yml | awk '{print $2}')
 
           if [ "$PUBLISHED_VERSION" != "$CURRENT_VERSION" ]; then
-            gh extension install github/gh-codeql
-            gh codeql pack install "${{ matrix.language }}/lib"
-            gh codeql pack publish "${{ matrix.language }}/lib"
+            codeql pack install "${{ matrix.language }}/lib"
+            codeql pack publish "${{ matrix.language }}/lib"
           fi
 
   extensions:
@@ -74,6 +88,14 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
+      - name: Initialize CodeQL
+        run: |
+          VERSION="$(find "${{ runner.tool_cache }}/CodeQL/" -maxdepth 1 -mindepth 1 -type d -print \
+                       | sort \
+                       | tail -n 1 \
+                       | tr -d '\n')"
+          echo "$VERSION/x64/codeql" >> $GITHUB_PATH
+
       - name: Check and publish codeql-LANG-extensions (ext) pack
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -82,9 +104,8 @@ jobs:
           CURRENT_VERSION=$(grep version ${{ matrix.language }}/ext/qlpack.yml | awk '{print $2}')
 
           if [ "$PUBLISHED_VERSION" != "$CURRENT_VERSION" ]; then
-            gh extension install github/gh-codeql
-            gh codeql pack install "${{ matrix.language }}/ext"
-            gh codeql pack publish "${{ matrix.language }}/ext"
+            codeql pack install "${{ matrix.language }}/ext"
+            codeql pack publish "${{ matrix.language }}/ext"
           fi
 
   library_sources_extensions:
@@ -98,6 +119,14 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
+      - name: Initialize CodeQL
+        run: |
+          VERSION="$(find "${{ runner.tool_cache }}/CodeQL/" -maxdepth 1 -mindepth 1 -type d -print \
+                       | sort \
+                       | tail -n 1 \
+                       | tr -d '\n')"
+          echo "$VERSION/x64/codeql" >> $GITHUB_PATH
+
       - name: Check and publish codeql-LANG-library-sources (ext-library-sources) pack
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -106,7 +135,6 @@ jobs:
           CURRENT_VERSION=$(grep version ${{ matrix.language }}/ext-library-sources/qlpack.yml | awk '{print $2}')
 
           if [ "$PUBLISHED_VERSION" != "$CURRENT_VERSION" ]; then
-            gh extension install github/gh-codeql
-            gh codeql pack install "${{ matrix.language }}/ext-library-sources"
-            gh codeql pack publish "${{ matrix.language }}/ext-library-sources"
+            codeql pack install "${{ matrix.language }}/ext-library-sources"
+            codeql pack publish "${{ matrix.language }}/ext-library-sources"
           fi


### PR DESCRIPTION
GitHub runners come with CodeQL already installed, we can use that instead of downloading `gh`'s extension to make workflows faster and less demanding.