### PR TITLE
Fix `defaultSuiteFile` path

### DIFF
--- a/cpp/src/qlpack.yml
+++ b/cpp/src/qlpack.yml
@@ -1,7 +1,7 @@
 library: false
 name: githubsecuritylab/codeql-cpp-queries
 version: 0.0.1
-defaultSuiteFile: suites/cpp.qls
+defaultSuiteFile: suites/suites/cpp.qls
 dependencies:
   codeql/cpp-all: '*'
   codeql/cpp-queries: '*'

--- a/csharp/src/qlpack.yml
+++ b/csharp/src/qlpack.yml
@@ -1,7 +1,7 @@
 library: false
 name: githubsecuritylab/codeql-csharp-queries
 version: 0.0.1
-defaultSuiteFile: suites/csharp.qls
+defaultSuiteFile: suites/suites/csharp.qls
 dependencies:
   codeql/csharp-all: '*'
   codeql/csharp-queries: '*' # Required for Dependencies.ql

--- a/go/src/qlpack.yml
+++ b/go/src/qlpack.yml
@@ -1,7 +1,7 @@
 library: false
 name: githubsecuritylab/codeql-go-queries
 version: 0.0.1
-defaultSuiteFile: suites/go.qls
+defaultSuiteFile: suites/suites/go.qls
 dependencies:
   codeql/go-all: '*'
   githubsecuritylab/codeql-go-libs: 0.0.1

--- a/java/src/qlpack.yml
+++ b/java/src/qlpack.yml
@@ -1,7 +1,7 @@
 library: false
 name: githubsecuritylab/codeql-java-queries
 version: 0.0.1
-defaultSuiteFile: suites/java.qls
+defaultSuiteFile: suites/suites/java.qls
 dependencies:
   codeql/java-all: '*'
   githubsecuritylab/codeql-java-libs: 0.0.1

--- a/python/src/qlpack.yml
+++ b/python/src/qlpack.yml
@@ -1,7 +1,7 @@
 library: false
 name: githubsecuritylab/codeql-python-queries
 version: 0.0.1
-defaultSuiteFile: suites/python.qls
+defaultSuiteFile: suites/suites/python.qls
 dependencies:
   codeql/python-all: '*'
   githubsecuritylab/codeql-python-libs: 0.0.1

--- a/ruby/src/qlpack.yml
+++ b/ruby/src/qlpack.yml
@@ -1,7 +1,7 @@
 library: false
 name: githubsecuritylab/codeql-ruby-queries
 version: 0.0.1
-defaultSuiteFile: suites/ruby.qls
+defaultSuiteFile: suites/suites/ruby.qls
 dependencies:
   codeql/ruby-all: '*'
   githubsecuritylab/codeql-ruby-libs: 0.0.1


### PR DESCRIPTION
```
@jorgectf ➜ /workspaces $ codeql database analyze foo/ --format=sarif-latest --output=test.sarif --download githubsecuritylab/codeql-python-queries
{
  "packs" : [
    {
      "name" : "githubsecuritylab/codeql-python-queries",
      "version" : "0.0.1",
      "library" : false,
      "result" : "INSTALLED"
    }
  ],
  "packDir" : "/home/vscode/.codeql/packages"
}
Running queries.
A fatal error occurred: Could not read /home/vscode/.codeql/packages/githubsecuritylab/codeql-python-queries/0.0.1/suites/python.qls
(eventual cause: NoSuchFileException "/home/vscode/.codeql/packages/githubsecuritylab/codeql-python-queries/0.0.1/suites/python.qls")
```

```
@jorgectf ➜ /workspaces $ ls /home/vscode/.codeql/packages/githubsecuritylab/codeql-python-queries/0.0.1/
audit/                .codeql/              codeql-pack.lock.yml  qlpack.yml            security/             suites/
@jorgectf ➜ /workspaces $ ls /home/vscode/.codeql/packages/githubsecuritylab/codeql-python-queries/0.0.1/suites/
suites
@jorgectf ➜ /workspaces $ ls /home/vscode/.codeql/packages/githubsecuritylab/codeql-python-queries/0.0.1/suites/suites/python
python-audit.qls                  python-local.qls                  python-security-experimental.qls  
python-external-api.qls           python.qls
```