### PR TITLE
Fixes pack rename in audit suites + adds CPP audit suite

### DIFF
--- a/cpp/src/suites/cpp-audit.qls
+++ b/cpp/src/suites/cpp-audit.qls
@@ -1,8 +1,8 @@
-- description: "GitHub's Community Packs CSharp Audit Suite"
+- description: "GitHub's Community Packs C/C++ Audit Suite"
 
 # Audit queries
 - queries: '.'
-  from: githubsecuritylab/codeql-csharp-queries
+  from: githubsecuritylab/codeql-cpp-queries
 - include:
     kind:
     - problem
@@ -14,7 +14,7 @@
 
 # External API query
 - queries: '.'
-  from: codeql/csharp-queries
+  from: codeql/cpp-queries
 - include:
     id:
-      - cs/untrusted-data-to-external-api
+      - cpp/untrusted-data-to-external-api

--- a/java/src/suites/java-audit.qls
+++ b/java/src/suites/java-audit.qls
@@ -2,7 +2,7 @@
 
 # Audit queries
 - queries: '.'
-  from: githubsecuritylab/java-queries
+  from: githubsecuritylab/codeql-java-queries
 - include:
     kind:
     - problem

--- a/java/src/suites/java-local.qls
+++ b/java/src/suites/java-local.qls
@@ -4,7 +4,7 @@
   from: codeql/java-queries
 
 - queries: '.'
-  from: githubsecuritylab/java-queries
+  from: githubsecuritylab/codeql-java-queries
 - include:
     id:
       - java/xxe-local


### PR DESCRIPTION
Changes
Resolve some inconsistencies using the old community pack names in the audit suites
```yml
packs:         
    #DNE 
    - githubsecuritylab/codeql-cpp-queries:suites/cpp-audit.qls
    # FAILS
    - githubsecuritylab/codeql-csharp-queries:suites/csharp-audit.qls
```
  - error: `A fatal error occurred: The QL pack 'githubsecuritylab/codeql-csharp' which is referenced from C:\.....\.codeql\packages\githubsecuritylab\codeql-csharp-queries\0.0.3\suites\csharp-audit.qls cannot be found.`
  - Adds audit suite for CPP

Here are the most important changes:

Changes to Audit Query Sources:

* [`cpp/src/suites/cpp-audit.qls`](diffhunk://#diff-e8b9c0e0a3df02943a5bc95163cbb41ee9425246a6413bd8a41dc9c74ed7981eR1-R20): Add suite with external API query was also added from `codeql/cpp-queries`.
* [`csharp/src/suites/csharp-audit.qls`](diffhunk://#diff-a80660eae6f86409a8733fae5200a391ef4b5bb3e87e4ad04dcaafb5276e59cbL5-R5): The source of the audit queries was changed from `githubsecuritylab/codeql-csharp` to `githubsecuritylab/codeql-csharp-queries`.
* [`java/src/suites/java-audit.qls`](diffhunk://#diff-102507a1fa1a3fdf09acf0cab01f6904141304ccf851c56b6ae5eb4bba881068L5-R5): The source of the audit queries was changed from `githubsecuritylab/java-queries` to `githubsecuritylab/codeql-java-queries`.
* [`java/src/suites/java-local.qls`](diffhunk://#diff-46261b5d521ef71b19ca258bc2e3a4a377a6404798be85ab67475630a07f5049L7-R7): The source of the audit queries was changed from `githubsecuritylab/java-queries` to `githubsecuritylab/codeql-java-queries`.