### PR TITLE
Java Local Queries

### DIFF
--- a/java/src/suites/java-local.qls
+++ b/java/src/suites/java-local.qls
@@ -12,4 +12,15 @@
 - queries: '.'
   from: codeql/java-queries
 - include:
-    tags contain: -local
+    id:
+      - java/path-injection-local
+      - java/command-line-injection-local
+      - java/xss-local
+      - java/sql-injection-local
+      - java/http-response-splitting-local
+      - java/improper-validation-of-array-construction-local
+      - java/improper-validation-of-array-index-local
+      - java/tainted-format-string-local
+      - java/tainted-arithmetic-local
+      - java/unvalidated-url-redirection-local
+      - java/tainted-numeric-cast-local


### PR DESCRIPTION
Not finding `codeql/java-queries` security queries that are tagged with `local` ... there are a handful of queries that are explicitly pulling in local sources.  (ref: https://github.com/advanced-security/codeql-queries/blob/main/java/suites/codeql-java-local.qls)

I presume this may change soon though when `threat-models: local` is operationalized