### PR TITLE
exclude CoverageResults html from interpreted scans

### DIFF
--- a/configs/synthetics.yml
+++ b/configs/synthetics.yml
@@ -112,3 +112,4 @@ paths-ignore:
     - "**/*.spec.ts"
     - "**/*.spec.tsx"
     - "dist"
+    - "CoverageResults"


### PR DESCRIPTION
This pull request includes a minor change to the `configs/synthetics.yml` file. The change adds `"CoverageResults"` to the `paths-ignore:` list, which means that any files in the `CoverageResults` directory will now be ignored in an interpreted language CodeQL scan.

This directory contains autogenerated files during standard code coverage tool execution and includes noise if running quality queries ( un-needed compute during security queries).  I have yet to find a better place to inventory all these common unwanted folders (ex: `dist` ) so this config file has turned into the best spot to inventory :) 

ex:
<img width="116" alt="image" src="https://github.com/GitHubSecurityLab/CodeQL-Community-Packs/assets/1760475/067d80a2-e105-4869-84ed-88b347dd5fd4">


