### PR TITLE
Create undertow-core.model.yml

### DIFF
--- a/java/ext/manual/undertow-core.model.yml
+++ b/java/ext/manual/undertow-core.model.yml
@@ -1,0 +1,25 @@
+extensions:
+  - addsTo:
+      pack: codeql/java-all
+      extensible: sourceModel
+    data:
+      - ["io.undertow.server","HttpServerExchange",true,"getQueryParameters","()","","ReturnValue","remote","ai-generated"]
+      - ["io.undertow.server","HttpServerExchange",true,"getResponseHeaders","()","","ReturnValue","remote","ai-generated"]
+
+  - addsTo:
+      pack: codeql/java-all
+      extensible: sinkModel
+    data:
+      - ["io.undertow.io","Sender",true,"send","(String)","","Argument[0]","js-injection","manual"]
+      - ["io.undertow.io","Sender",true,"send","(String)","","Argument[0]","html-injection","manual"]
+      - ["io.undertow.util","HeaderMap",true,"put","(HttpString,String)","","Argument[0]","response-splitting","manual"]
+
+  - addsTo:
+      pack: codeql/java-all
+      extensible: summaryModel
+    data: []
+
+  - addsTo:
+      pack: codeql/java-all
+      extensible: neutralModel
+    data: []


### PR DESCRIPTION
Adds model for  `java/ext/manual/undertow-core.model.yml`  - this is not complete just to start with the XSS and additional header splitting sink.

Added this to the `java/ext/manual` directory but I am lacking clear guidance on which folders to put this in `ext` vs `ext-library-sources` and `generated` vs `manual` ... I used the model editor with some ai for a library... so a little of all 4 ?

XSS sample vuln detected using model: https://github.com/vulna-felickz/java-undertow-fn/security/code-scanning/3
<img width="462" alt="image" src="https://github.com/GitHubSecurityLab/CodeQL-Community-Packs/assets/1760475/d8f79ade-2275-42e8-92a5-dbd886477a4a">
