### PR TITLE
Synthetic Config - remove wwwroot/lib for .net JS libraries

### DIFF
--- a/configs/synthetics.yml
+++ b/configs/synthetics.yml
@@ -112,4 +112,5 @@ paths-ignore:
     - "**/*.spec.ts"
     - "**/*.spec.tsx"
     - "dist"
-    - "CoverageResults"
+    - "CoverageResults"    
+    - "**/wwwroot/lib/**"


### PR DESCRIPTION
This pull request includes a small change to the `configs/synthetics.yml` file. The change adds a new path to the `paths-ignore:` section, specifically `**/wwwroot/lib/**`, to exclude it from certain operations or workflows.


`/wwwroot/lib/` is a common directory for storing JavaScript libraries in ASP.NET Core applications.

ASP.NET Core introduces the wwwroot folder as the location to store static files, including JavaScript libraries, CSS files, images, and other client-side assets.

The `/wwwroot/lib/` directory specifically is often used to store third-party or vendor JavaScript libraries, like jQuery or Bootstrap. These libraries can be managed through package managers such as npm or libman, or manually included in your project.