### PR TITLE
JS: add templates for forward and backwards data flow

### DIFF
--- a/javascript/src/audit/templates/BackwardsDataFlow.ql
+++ b/javascript/src/audit/templates/BackwardsDataFlow.ql
@@ -1,0 +1,31 @@
+/**
+ * @name Backwards Dataflow
+ * @description Backwards Dataflow (Note: backwards (partial) dataflow works differently in CodeQL for JavaScript, e.g. no PartialPathGraph is available.)
+ * @kind path-problem
+ * @precision low
+ * @problem.severity error
+ * @id githubsecuritylab/backwards-dataflow
+ * @tags template
+ */
+
+ import javascript
+ import DataFlow::PathGraph
+ import semmle.javascript.explore.BackwardDataFlow
+ 
+ class BackwardDataFlowConfig extends TaintTracking::Configuration {
+   BackwardDataFlowConfig() { this = "BackwardDataFlowConfig" }
+ 
+   // `isSource` is ignored when `semmle.javascript.explore.BackwardDataFlow` is imported.
+ 
+   override predicate isSink(DataFlow::Node sink) {
+     // Define the sink to run the backwards dataflow from. Eg:
+     // sink = API::moduleImport("module").getMember("method").getParameter(0).asSink()
+     none()
+   }
+ }
+ 
+ from BackwardDataFlowConfig cfg, DataFlow::PathNode source, DataFlow::PathNode sink
+ where cfg.hasFlowPath(source, sink)
+ select sink.getNode(), source, sink, "This node receives taint from $@.", source.getNode(),
+   "this source"
+ 

--- a/javascript/src/audit/templates/ForwardDataFlow.ql
+++ b/javascript/src/audit/templates/ForwardDataFlow.ql
@@ -1,0 +1,31 @@
+/**
+ * @name Forward Dataflow
+ * @description Forward Dataflow (Note: forward (partial) dataflow works differently in CodeQL for JavaScript, e.g. no PartialPathGraph is available.)
+ * @kind path-problem
+ * @precision low
+ * @problem.severity error
+ * @id githubsecuritylab/forward-dataflow
+ * @tags template
+ */
+
+ import javascript
+ import DataFlow::PathGraph
+ import semmle.javascript.explore.ForwardDataFlow
+ 
+ class ForwardDataFlowConfig extends TaintTracking::Configuration {
+   ForwardDataFlowConfig() { this = "ForwardDataFlowConfig" }
+ 
+   override predicate isSource(DataFlow::Node source) {
+     // Define the source to run the forward dataflow from. Eg:
+     // source = API::moduleImport(_).getMember("method").getReturn().asSource()
+     none()
+   }
+ 
+   // `isSink` is ignored when `semmle.javascript.explore.ForwardDataFlow` is imported.
+ }
+ 
+ from ForwardDataFlowConfig cfg, DataFlow::PathNode source, DataFlow::PathNode sink
+ where cfg.hasFlowPath(source, sink)
+ select sink.getNode(), source, sink, "This node receives taint from $@.", source.getNode(),
+   "this source"
+ 


### PR DESCRIPTION
Add initial templates for forward and backwards data flow when using CodeQL for JS.