### PR TITLE
Add even better dev container support with some scripts

### DIFF
--- a/.devcontainer/bootstrap.sh
+++ b/.devcontainer/bootstrap.sh
@@ -1,9 +1,18 @@
 #!/bin/bash
+set -e
 
-# Install CodeQL Stub
-cp ./.devcontainer/codeql.sh /usr/local/bin/codeql
+echo "Installing GH Extensions..."
+gh extensions install GitHubSecurityLab/gh-mrva
+gh extensions install advanced-security/gh-codeql-scan
+
+echo "Installing stubs..."
+chmod +x .devcontainer/scripts/* && cp -r .devcontainer/scripts/* /usr/local/bin/
 
 # Clone an instance of the CodeQL repository
+# https://github.com/github/codeql/tree/codeql-cli/latest
+echo "Cloning CodeQL repository..."
 if [ ! -d "./codeql" ]; then
-  git clone --depth=1 https://github.com/github/codeql ./codeql
+  git clone \
+    --branch codeql-cli/latest \
+    https://github.com/github/codeql ./codeql
 fi

--- a/.devcontainer/codeql.sh
+++ b/.devcontainer/codeql.sh
@@ -1,2 +1,0 @@
-#!/bin/bash
-/root/.vscode-remote/data/User/globalStorage/github.vscode-codeql/distribution1/codeql/codeql $@

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -9,7 +9,13 @@
     "extensions": [
         "github.vscode-codeql",
         "github.copilot",
+        "MS-vsliveshare.vsliveshare",
+        "lostintangent.github-security-alerts",
         "ms-vscode.test-adapter-converter",
+        "ms-vscode.cpptools",
+        "ms-dotnettools.vscode-dotnet-runtime",
+        "ms-python.vscode-pylance",
+        "redhat.java",
     ],
     "settings": {
         "codeQL.canary": true,

--- a/.devcontainer/scripts/codeql
+++ b/.devcontainer/scripts/codeql
@@ -1,0 +1,11 @@
+#!/bin/bash
+set -e
+
+CODEQL_PATH=/home/root/.vscode-remote/data/User/globalStorage/github.vscode-codeql/distribution1/codeql/codeql
+
+if [ ! -f $CODEQL_PATH ]; then
+    echo "CodeQL not found. Please install the CodeQL extension in VSCode and try again."
+    exit 1
+fi
+
+$CODEQL_PATH $@

--- a/.devcontainer/scripts/codeql-scan
+++ b/.devcontainer/scripts/codeql-scan
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+gh codeql-scan $@


### PR DESCRIPTION
* [`.devcontainer/bootstrap.sh`](diffhunk://#diff-51ffed8ea97ed57573c46599688c9d0dba4297f46a34c43c42e736cca1d6130eR2-R17): The CodeQL stub is no longer installed, and instead, two GitHub extensions, `GitHubSecurityLab/gh-mrva` and `advanced-security/gh-codeql-scan`, are installed. The script files in the `.devcontainer/scripts/` directory are now made executable and copied to `/usr/local/bin/`. The CodeQL repository cloning process has also been updated to clone from the `codeql-cli/latest` branch.

* [`.devcontainer/codeql.sh`](diffhunk://#diff-be9b9635417c512e68e2e5b6fb4dde0061886e7a9e7fb307fbab76056b8dd8e7L1-L2): This file has been completely removed.

* [`.devcontainer/devcontainer.json`](diffhunk://#diff-24ad71c8613ddcf6fd23818cb3bb477a1fb6d83af4550b0bad43099813088686R12-R18): Several new Visual Studio Code extensions have been added to the development environment, including `MS-vsliveshare.vsliveshare`, `lostintangent.github-security-alerts`, `ms-vscode.cpptools`, `ms-dotnettools.vscode-dotnet-runtime`, `ms-python.vscode-pylance`, and `redhat.java`.

* [`.devcontainer/scripts/codeql`](diffhunk://#diff-fc75ba489878ac05d25881f41b81f1ac6ce2a0b003f3af1f5242479f1c5db9d5R1-R11): This new script file checks for the existence of CodeQL in the path and runs it, or else it displays an error message asking to install the CodeQL extension in VSCode.

* [`.devcontainer/scripts/codeql-scan`](diffhunk://#diff-082816a3705fa0a0ded91583a8fe199b393957a65c28224826cf37f59d976eb3R1-R3): This new script file runs the `gh codeql-scan` command.