### PR TITLE
CodeQL Synthetic Config - Add additional 3rd party paths to ignore

### DIFF
--- a/configs/synthetics.yml
+++ b/configs/synthetics.yml
@@ -104,6 +104,7 @@ paths-ignore:
     - "vendor/**"
     - "examples/**"
     - "tests/**"
+    - "site-packages/**"
 
     # JavaScript
     - "node_modules"
@@ -114,3 +115,13 @@ paths-ignore:
     - "dist"
     - "CoverageResults"    
     - "**/wwwroot/lib/**"
+    - "**/deps/**"
+    - "**/third_party/**"
+
+    # Java (build-mode: none)
+    - "**/lib/**"
+
+    # Ruby
+    - "**/gems/**"
+    
+    


### PR DESCRIPTION
This is currently the best reference that aggregates this list of installed/vendored dependency folders that cause CodeQL to report vulns in 3rd party code.

Ex: https://github.com/nodejs/node/tree/main/deps


Ref: 
- https://ghsecuritylab.slack.com/archives/CQJN6KQHX/p1718740573865399