### PR TITLE
Test execution should target directory.

### DIFF
--- a/.github/scripts/pr-tests.sh
+++ b/.github/scripts/pr-tests.sh
@@ -28,7 +28,8 @@ for file in $(gh pr view "$PR_NUMBER" --json files --jq '.files.[].path'); do
     elif [[ "$file" == $LANGUAGE/**.ql ]] || [[ "$file" == $LANGUAGE/**.qll ]] ; then
         echo "[+] Query $file changed (in $LANGUAGE)"
 
-        SRC_DIR=$(realpath --relative-to="./${LANGUAGE}/src" "$file")
+        SRC_FILE=$(realpath --relative-to="./${LANGUAGE}/src" "$file")
+        SRC_DIR=$(dirname "$SRC_FILE")
         TEST_DIR=./${LANGUAGE}/test/${SRC_DIR}
         
         if [[ -d "$TEST_DIR" ]]; then


### PR DESCRIPTION
It turns out that the CI targets test files with the same name as the corresponding query files (just in a test location). This only works in case the test file has the exact same name as the query file in the source directory (this is for instance not the case for `.qlref` files).
In this PR we make a quick and dirty fix, which enables test execution of *all* tests in the corresponding test folder for a query.

We probably need to streamline the work for test execution, if we intend that this QL pack should contain many queries.
I think that with the current implementation of test execution, we
- Might risk that tests are executed multiple times in case there are modifications to multiple files in the same *src* directory.
- Might risk that not all relevant tests are executed in case they are not in the exact expected location and if the implicit assumption on dependencies change.
- Might risk that test execution doesn't scale well (with this change the test execution on my draft PR for moving C# experimental queries takes around 35 minutes to execute).

A source of inspiration could be: https://github.com/github/codeql-coding-standards/blob/main/.github/workflows/codeql_unit_tests.yml