### PR TITLE
Install a specific CodeQL version.

### DIFF
--- a/.github/actions/install-codeql/action.yml
+++ b/.github/actions/install-codeql/action.yml
@@ -1,0 +1,48 @@
+name: Setup CodeQL CLI
+description: |
+  Install a CodeQL CLI or re-use an existing one from the cache and it to the path.
+inputs:
+  codeql-cli-version:
+    description: |
+      The version of the CodeQL CLI to be downloaded.
+
+runs:
+  using: composite
+  steps:
+    - name: Cache CodeQL
+      id: cache-codeql
+      uses: actions/cache@v4
+      with:
+        # A list of files, directories, and wildcard patterns to cache and restore
+        path: ${{github.workspace}}/codeql_home
+        # An explicit key for restoring and saving the cache
+        key: codeql-home-${{ inputs.codeql-cli-version }}
+  
+    - name: Install CodeQL
+      if: steps.cache-codeql.outputs.cache-hit != 'true'
+      shell: bash
+      env:
+        GITHUB_TOKEN: ${{ github.token }}
+        CODEQL_HOME: ${{ github.workspace }}/codeql_home
+        CODEQL_CLI_VERSION: ${{ inputs.codeql-cli-version }}
+      run: |
+        mkdir -p $CODEQL_HOME
+        echo "Change directory to $CODEQL_HOME"
+        pushd $CODEQL_HOME
+
+        echo "Downloading CodeQL CLI v${CODEQL_CLI_VERSION}."
+        gh release download "v${CODEQL_CLI_VERSION}" --repo https://github.com/github/codeql-cli-binaries --pattern codeql-linux64.zip
+
+        echo "Unzipping CodeQL CLI."
+        unzip -q codeql-linux64.zip
+
+        popd
+        echo "Done."
+
+    - name: Add CodeQL to the PATH
+      shell: bash
+      env:
+        CODEQL_HOME: ${{ github.workspace }}/codeql_home
+      run: |
+        echo "Adding CodeQL CLI to the PATH."
+        echo "$CODEQL_HOME/codeql" >> $GITHUB_PATH

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,9 @@ on:
     branches: [ main ]
   workflow_dispatch:
 
+env:
+  CODEQL_CLI_VERSION: 2.19.2
+
 jobs:
   compile-and-test:
     runs-on: ubuntu-latest
@@ -25,15 +28,12 @@ jobs:
             src:
               - '${{ matrix.language }}/**'
 
-      - name: Initialize CodeQL
+      - name: Setup CodeQL
         if: steps.changes.outputs.src == 'true'
-        run: |
-          VERSION="$(find "${{ runner.tool_cache }}/CodeQL/" -maxdepth 1 -mindepth 1 -type d -print \
-                       | sort \
-                       | tail -n 1 \
-                       | tr -d '\n')"
-          echo "$VERSION/x64/codeql" >> $GITHUB_PATH
-        
+        uses: ./.github/actions/install-codeql
+        with:
+          codeql-cli-version: ${{ env.CODEQL_CLI_VERSION }}
+
       - name: Install Packs
         if: steps.changes.outputs.src == 'true'
         env:
@@ -171,14 +171,11 @@ jobs:
             src:
               - '${{ matrix.language }}/ext/**'
 
-      - name: Initialize CodeQL
+      - name: Setup CodeQL
         if: steps.changes.outputs.src == 'true'
-        run: |
-          VERSION="$(find "${{ runner.tool_cache }}/CodeQL/" -maxdepth 1 -mindepth 1 -type d -print \
-                       | sort \
-                       | tail -n 1 \
-                       | tr -d '\n')"
-          echo "$VERSION/x64/codeql" >> $GITHUB_PATH
+        uses: ./.github/actions/install-codeql
+        with:
+          codeql-cli-version: ${{ env.CODEQL_CLI_VERSION }}
 
       - name: Install Packs
         if: steps.changes.outputs.src == 'true'
@@ -209,14 +206,11 @@ jobs:
             src:
               - '${{ matrix.language }}/ext-library-sources/**'
 
-      - name: Initialize CodeQL
+      - name: Setup CodeQL
         if: steps.changes.outputs.src == 'true'
-        run: |
-          VERSION="$(find "${{ runner.tool_cache }}/CodeQL/" -maxdepth 1 -mindepth 1 -type d -print \
-                       | sort \
-                       | tail -n 1 \
-                       | tr -d '\n')"
-          echo "$VERSION/x64/codeql" >> $GITHUB_PATH
+        uses: ./.github/actions/install-codeql
+        with:
+          codeql-cli-version: ${{ env.CODEQL_CLI_VERSION }}
 
       - name: Install CodeQL
         if: steps.changes.outputs.src == 'true'
@@ -240,14 +234,11 @@ jobs:
             src:
               - 'configs/**'
       
-      - name: Initialize CodeQL
+      - name: Setup CodeQL
         if: steps.changes.outputs.src == 'true'
-        run: |
-          VERSION="$(find "${{ runner.tool_cache }}/CodeQL/" -maxdepth 1 -mindepth 1 -type d -print \
-                       | sort \
-                       | tail -n 1 \
-                       | tr -d '\n')"
-          echo "$VERSION/x64/codeql" >> $GITHUB_PATH
+        uses: ./.github/actions/install-codeql
+        with:
+          codeql-cli-version: ${{ env.CODEQL_CLI_VERSION }}
 
       - name: "Check Configurations"
         if: steps.changes.outputs.src == 'true'


### PR DESCRIPTION
In this PR we add an action for downloading and caching a specific version of the CodeQL CLI instead of using what is in the tool cache. I ran into some issues with code suddenly not compiling when new CodeQL versions were picked up from the tool cache - so maybe we should consider to pin the CodeQL version? If not, we could also modify these workflows to download the latest CodeQL CLI instead.
Also we get all sorts of warnings during package install (subsequent steps) using the codeql in the tool cache (I think this is because the tool cache contains the entire bundle).

If we decide to use this "new" action, both the *hotspots* and *publish* workflows also needs to be updated.
