### PR TITLE
intro blog post in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,8 @@
 </div>
 <!-- markdownlint-restore -->
 
-Collection of community-driven CodeQL query, library and extension packs
+Collection of community-driven CodeQL query, library and extension packs.
+- A detailed introduction via the GitHub Blog: [Announcing CodeQL Community Packs](https://github.blog/security/vulnerability-research/announcing-codeql-community-packs/)
 
 ## Getting started
 


### PR DESCRIPTION
This pull request includes a small change to the `README.md` file. Adds a link to the a detailed introduction on the GitHub Blog: https://github.blog/security/vulnerability-research/announcing-codeql-community-packs/.