### PR TITLE
Use GH 1st party actions/create-github-app-token

### DIFF
--- a/.github/workflows/update-release.yml
+++ b/.github/workflows/update-release.yml
@@ -23,10 +23,10 @@ jobs:
 
       - name: Get Token
         id: get_workflow_token
-        uses: peter-murray/workflow-application-token-action@8e4e6fbf6fcc8a272781d97597969d21b3812974 # v4.0.0
+        uses: actions/create-github-app-token@v1
         with:
-          application_id: ${{ secrets.SECLABS_APP_ID }}
-          application_private_key: ${{ secrets.SECLABS_APP_KEY }}
+          app-id: ${{ secrets.SECLABS_APP_ID }}
+          private-key: ${{ secrets.SECLABS_APP_KEY }}          
 
       - name: "Patch Release Me"
         uses: 42ByteLabs/patch-release-me@1e802ecb51cf4c5869cb77563df59b2fbe6f584c # 0.4.1

--- a/.github/workflows/update-release.yml
+++ b/.github/workflows/update-release.yml
@@ -26,7 +26,7 @@ jobs:
         uses: actions/create-github-app-token@v1
         with:
           app-id: ${{ secrets.SECLABS_APP_ID }}
-          private-key: ${{ secrets.SECLABS_APP_KEY }}          
+          private-key: ${{ secrets.SECLABS_APP_KEY }}
 
       - name: "Patch Release Me"
         uses: 42ByteLabs/patch-release-me@1e802ecb51cf4c5869cb77563df59b2fbe6f584c # 0.4.1


### PR DESCRIPTION
This pull request includes a change to the GitHub Actions workflow configuration file `.github/workflows/update-release.yml`. The change updates the action used to generate a GitHub App token to use [actions/create-github-app-token](https://github.com/actions/create-github-app-token) .

- trusted publisher not pinned