### PR TITLE
Remove "Change notes" section

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,10 +4,6 @@ We welcome contributions to our CodeQL Community Packs libraries and queries. Go
 
 There is lots of useful documentation to help you write queries, ranging from information about query file structure to tutorials for specific target languages. For more information on the documentation available, see [CodeQL queries](https://codeql.github.com/docs/writing-codeql-queries/codeql-queries) on [codeql.github.com](https://codeql.github.com).
 
-## Change notes
-
-Any nontrivial user-visible change to a query pack or library pack should have a change note. For details on how to add a change note for your change, see [this guide](docs/change-notes.md).
-
 ## Submitting a new query
 
 If you have an idea for a query that you would like to share with other CodeQL users, please open a pull request to add it to this repository. New queries start out in a `<language>/ql/src/` directory, to which they can be merged when they meet the following requirements.


### PR DESCRIPTION
This section contains a broken link to `docs/change-notes.md`. I think we only have this section because this file was originally copy-pasted from https://github.com/github/codeql/blob/main/CONTRIBUTING.md, so we should just remove it. Thanks to @jcogs33 and @yo-h for pointing it out.