### PR TITLE
Add local sources to audit config

### DIFF
--- a/configs/audit.yml
+++ b/configs/audit.yml
@@ -1,5 +1,7 @@
 name: "GitHub Community Pack Audit Configuration"
 
+threat-models: local
+
 packs:
   # C/C++
   - githubsecuritylab/codeql-cpp-queries:suites/cpp-audit.qls


### PR DESCRIPTION
>   Warning: Both a config file and config input were provided. Ignoring config file.


You cannot run this config along with local sources via config.  I would argue that when looking for audit results, local sources would be additional inputs that are warranted.  Alternative would be to maintain two configs here otherwise.