### PR TITLE
Fix indentation for 'pack' and 'extensible' fields in model YAML files

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -132,16 +132,17 @@ jobs:
 
       - name: Validate test results
         run: |
-          if [[ ! -n "$(find . -name 'test_report_*' -print -quit)" ]]; then
+          mapfile -t test_reports < <(find . -name 'test_report_*.json')
+          if [[ ${#test_reports[@]} -eq 0 ]]; then
             echo "No test results found"
             exit 0
           fi
 
-          for json_report in *-test-results/test_report_*
+          for json_report in "${test_reports[@]}"
           do
-            jq --raw-output '"PASS \(map(select(.pass == true)) | length)/\(length)'" $json_report\"" "$json_report"
+            jq --raw-output '"PASS \(map(select(.pass == true)) | length)/\(length)"' "$json_report"
           done
-          FAILING_TESTS=$(jq --raw-output '.[] | select(.pass == false)' *-test-results/test_report_*.json)
+          FAILING_TESTS=$(jq --raw-output '.[] | select(.pass == false)' "${test_reports[@]}")
           if [[ ! -z "$FAILING_TESTS" ]]; then
             echo "ERROR: The following tests failed:"
             echo $FAILING_TESTS | jq .

--- a/python/ext/generated/flask.model.yml
+++ b/python/ext/generated/flask.model.yml
@@ -1,7 +1,7 @@
 extensions:
     - addsTo:
-      pack: codeql/python-all
-      extensible: sourceModel
+        pack: codeql/python-all
+        extensible: sourceModel
       data:
           - ["flask", "Member[app].Member[Flask].Instance.Member[open_instance_resource]", "Argument[1,resource:]", "file"]
           - ["flask", "Member[app].Member[Flask].Instance.Member[open_instance_resource]", "Argument[2,mode:]", "file"]
@@ -41,8 +41,8 @@ extensions:
           - ["flask", "Member[sessions].Member[SecureCookieSessionInterface].Instance.Member[open_session]", "Argument[1,app:]", "remote"]
           - ["flask", "Member[sessions].Member[SecureCookieSessionInterface].Instance.Member[save_session]", "Argument[1,app:]", "remote"]
     - addsTo:
-      pack: codeql/python-all
-      extensible: sinkModel
+        pack: codeql/python-all
+        extensible: sinkModel
       data:
           - ["flask", "Member[app].Member[Flask].Instance.Member[open_instance_resource]", "Argument[1,resource:]", "path-injection"]
           - ["flask", "Member[app].Member[Flask].Instance.Member[open_resource]", "Argument[1,resource:]", "path-injection"]
@@ -53,8 +53,8 @@ extensions:
           - ["flask", "Member[config].Member[Config].Instance.Member[from_file]", "Argument[1,filename:]", "path-injection"]
           - ["flask", "Member[config].Member[Config].Instance.Member[from_pyfile]", "Argument[1,filename:]", "path-injection"]
     - addsTo:
-      pack: codeql/python-all
-      extensible: summaryModel
+        pack: codeql/python-all
+        extensible: summaryModel
       data:
           - ["flask", "Member[app].Member[Flask].Instance.Member[app_context]", "Argument[self]", "ReturnValue", "taint"]
           - ["flask", "Member[app].Member[Flask].Instance.Member[create_jinja_environment]", "Argument[self]", "ReturnValue", "taint"]

--- a/python/ext/generated/ghastoolkit.model.yml
+++ b/python/ext/generated/ghastoolkit.model.yml
@@ -1,7 +1,7 @@
 extensions:
     - addsTo:
-      pack: codeql/python-all
-      extensible: sourceModel
+        pack: codeql/python-all
+        extensible: sourceModel
       data:
           - ["ghastoolkit", "Member[codeql].Member[cli].Member[CodeQL].Instance.Member[getResults]", "Argument[1,database:]", "file"]
           - ["ghastoolkit", "Member[codeql].Member[cli].Member[CodeQL].Instance.Member[getResults]", "Argument[2,path:]", "file"]
@@ -55,8 +55,8 @@ extensions:
           - ["ghastoolkit", "Member[supplychain].Member[licensing].Member[Licenses].Instance.Member[load]", "Argument[1,path:]", "file"]
           - ["ghastoolkit", "Member[utils].Member[cli].Member[CommandLine].Instance.Member[parse_args]", "ReturnValue", "commandargs"]
     - addsTo:
-      pack: codeql/python-all
-      extensible: sinkModel
+        pack: codeql/python-all
+        extensible: sinkModel
       data:
           - ["ghastoolkit", "Member[codeql].Member[cli].Member[CodeQL].Instance.Member[getResults]", "Argument[1,database:]", "path-injection"]
           - ["ghastoolkit", "Member[codeql].Member[cli].Member[CodeQL].Instance.Member[runQuery]", "Argument[1,database:]", "path-injection"]
@@ -77,8 +77,8 @@ extensions:
           - ["ghastoolkit", "Member[supplychain].Member[licensing].Member[Licenses].Instance.Member[generateLockfile]", "Argument[1,path:]", "path-injection"]
           - ["ghastoolkit", "Member[supplychain].Member[licensing].Member[Licenses].Instance.Member[load]", "Argument[1,path:]", "path-injection"]
     - addsTo:
-      pack: codeql/python-all
-      extensible: summaryModel
+        pack: codeql/python-all
+        extensible: summaryModel
       data:
           - ["ghastoolkit", "Member[codeql].Member[cli].Member[CodeQL].Instance.Member[createDatabase]", "Argument[1,database:]", "ReturnValue", "taint"]
           - ["ghastoolkit", "Member[codeql].Member[cli].Member[CodeQL].Instance.Member[createDatabase]", "Argument[2,output:]", "ReturnValue", "taint"]

--- a/python/ext/generated/itsdangerous.model.yml
+++ b/python/ext/generated/itsdangerous.model.yml
@@ -1,7 +1,7 @@
 extensions:
     - addsTo:
-      pack: codeql/python-all
-      extensible: summaryModel
+        pack: codeql/python-all
+        extensible: summaryModel
       data:
           - ["itsdangerous", "Member[encoding].Member[base64_decode]", "Argument[0,string:]", "ReturnValue", "taint"]
           - ["itsdangerous", "Member[encoding].Member[base64_encode]", "Argument[0,string:]", "ReturnValue", "taint"]

--- a/python/ext/generated/openai.model.yml
+++ b/python/ext/generated/openai.model.yml
@@ -1,7 +1,7 @@
 extensions:
     - addsTo:
-      pack: codeql/python-all
-      extensible: sourceModel
+        pack: codeql/python-all
+        extensible: sourceModel
       data:
           - ["openai", "Argument[self]", "file"]
           - ["openai", "Member[_legacy_response].Member[HttpxBinaryResponseContent].Instance.Member[stream_to_file]", "Argument[1,file:]", "file"]
@@ -24,8 +24,8 @@ extensions:
           - ["openai", "Member[lib].Member[_validators].Member[read_any_format]", "Argument[self]", "file"]
           - ["openai", "Member[lib].Member[_validators].Member[read_any_format]", "ReturnValue", "file"]
     - addsTo:
-      pack: codeql/python-all
-      extensible: summaryModel
+        pack: codeql/python-all
+        extensible: summaryModel
       data:
           - ["openai", "Argument[self]", "Argument[1,_fields_set:]", "taint"]
           - ["openai", "Member[_base_client].Member[AsyncAPIClient].Instance.Member[delete]", "Argument[self]", "ReturnValue", "taint"]

--- a/python/ext/generated/pymysql.model.yml
+++ b/python/ext/generated/pymysql.model.yml
@@ -1,15 +1,15 @@
 extensions:
     - addsTo:
-      pack: codeql/python-all
-      extensible: sinkModel
+        pack: codeql/python-all
+        extensible: sinkModel
       data:
           - ["pymysql", "Member[connections].Member[Connection].Instance.Member[connect]", "Argument[1,sock:]", "path-injection"]
           - ["pymysql", "Member[connections].Member[Connection].Instance.Member[connect]", "Argument[1,sock:]", "sql-injection"]
           - ["pymysql", "Member[cursors].Member[Cursor].Instance.Member[executemany]", "Argument[1,query:]", "sql-injection"]
           - ["pymysql", "Member[cursors].Member[Cursor].Instance.Member[executemany]", "Argument[2,args:]", "sql-injection"]
     - addsTo:
-      pack: codeql/python-all
-      extensible: summaryModel
+        pack: codeql/python-all
+        extensible: summaryModel
       data:
           - ["pymysql", "Member[Binary]", "Argument[0,x:]", "ReturnValue", "taint"]
           - ["pymysql", "Member[_auth].Member[caching_sha2_password_auth]", "Argument[1,pkt:]", "Argument[0,conn:]", "taint"]

--- a/python/ext/generated/urllib3.model.yml
+++ b/python/ext/generated/urllib3.model.yml
@@ -1,7 +1,7 @@
 extensions:
     - addsTo:
-      pack: codeql/python-all
-      extensible: sourceModel
+        pack: codeql/python-all
+        extensible: sourceModel
       data:
           - ["urllib3", "Member[util].Member[ssl_].Member[create_urllib3_context]", "Argument[0,ssl_version:]", "environment"]
           - ["urllib3", "Member[util].Member[ssl_].Member[create_urllib3_context]", "Argument[3,ciphers:]", "environment"]
@@ -10,13 +10,13 @@ extensions:
           - ["urllib3", "Member[util].Member[ssl_].Member[ssl_wrap_socket]", "Argument[6,ssl_version:]", "environment"]
           - ["urllib3", "Member[util].Member[ssl_].Member[ssl_wrap_socket]", "Argument[7,ciphers:]", "environment"]
     - addsTo:
-      pack: codeql/python-all
-      extensible: sinkModel
+        pack: codeql/python-all
+        extensible: sinkModel
       data:
           - ["urllib3", "Member[util].Member[ssl_].Member[ssl_wrap_socket]", "Argument[1,keyfile:]", "path-injection"]
     - addsTo:
-      pack: codeql/python-all
-      extensible: summaryModel
+        pack: codeql/python-all
+        extensible: summaryModel
       data:
           - ["urllib3", "Member[_collections].Member[HTTPHeaderDict].Instance.Member[getlist]", "Argument[2,default:]", "ReturnValue", "taint"]
           - ["urllib3", "Member[_collections].Member[HTTPHeaderDict].Instance.Member[getlist]", "Argument[self]", "ReturnValue", "taint"]

--- a/python/ext/generated/werkzeug.model.yml
+++ b/python/ext/generated/werkzeug.model.yml
@@ -1,7 +1,7 @@
 extensions:
     - addsTo:
-      pack: codeql/python-all
-      extensible: sourceModel
+        pack: codeql/python-all
+        extensible: sourceModel
       data:
           - ["werkzeug", "Member[_reloader].Member[ReloaderLoop].Instance.Member[restart_with_reloader]", "ReturnValue", "environment"]
           - ["werkzeug", "Member[_reloader].Member[run_with_reloader]", "Argument[0,main_func:]", "environment"]
@@ -49,8 +49,8 @@ extensions:
           - ["werkzeug", "Member[utils].Member[send_from_directory]", "Argument[2,environ:]", "file"]
           - ["werkzeug", "Member[utils].Member[send_from_directory]", "ReturnValue", "file"]
     - addsTo:
-      pack: codeql/python-all
-      extensible: sinkModel
+        pack: codeql/python-all
+        extensible: sinkModel
       data:
           - ["werkzeug", "Member[datastructures].Member[file_storage].Member[FileMultiDict].Instance.Member[add_file]", "Argument[2,file:]", "path-injection"]
           - ["werkzeug", "Member[datastructures].Member[file_storage].Member[FileStorage].Instance.Member[save]", "Argument[1,dst:]", "path-injection"]
@@ -64,8 +64,8 @@ extensions:
           - ["werkzeug", "Member[utils].Member[send_file]", "Argument[0,path_or_file:]", "path-injection"]
           - ["werkzeug", "Member[utils].Member[send_file]", "Argument[11,_root_path:]", "path-injection"]
     - addsTo:
-      pack: codeql/python-all
-      extensible: summaryModel
+        pack: codeql/python-all
+        extensible: summaryModel
       data:
           - ["werkzeug", "Member[datastructures].Member[accept].Member[Accept].Instance.Member[best_match]", "Argument[1,matches:]", "ReturnValue", "taint"]
           - ["werkzeug", "Member[datastructures].Member[accept].Member[Accept].Instance.Member[best_match]", "Argument[2,default:]", "ReturnValue", "taint"]


### PR DESCRIPTION
Fixing error when running with model packs enabled in IDE with CodeQL extension:

# BROKEN (original)
    - addsTo:
      pack: codeql/python-all
      extensible: sourceModel
      data:

# FIXED
    - addsTo:
        pack: codeql/python-all
        extensible: sourceModel
      data: