### PR TITLE
fix(java): remove duplicate codeql-java-extensions dependency causing fatal analysis crash

### DIFF
--- a/java/lib/qlpack.yml
+++ b/java/lib/qlpack.yml
@@ -1,6 +1,5 @@
 library: true 
 name: githubsecuritylab/codeql-java-libs
-version: 0.2.2
+version: 0.2.3
 dependencies:
   codeql/java-all: '*'
-  githubsecuritylab/codeql-java-extensions: '*'


### PR DESCRIPTION
> **Stacked on #126.** This PR is based on `jcogs33/update-to-v0.2.2` (PR #126), which does a blanket repo-wide version bump including `java/lib/qlpack.yml` → `0.2.2`. Since that version will already be published (with this bug still present) once #126 lands, this PR bumps `java/lib` to **`0.2.3`** instead, so the fix actually triggers a republish. Once #126 merges to `main`, this PR's base should be updated to `main` (the diff will be unchanged — just the removed dependency line and the version bump to 0.2.3).

## Bug

Any Java scan using one of this repo's published configs (`configs/default.yml`, `configs/synthetics.yml`, `configs/audit.yml`) fails with a fatal CodeQL error:

```
com.semmle.util.exception.CatastrophicError: Encountered two packs with the same name 'Optional[githubsecuritylab/codeql-java-extensions]' used in a single evaluation.
```

Confirmed against a real, 100%-reproducible failing GitHub Actions run using `configs/synthetics.yml` verbatim from this repo: [dsp-testing/SecurityShepherd run 28809261039, job 85432641504](https://github.com/dsp-testing/SecurityShepherd/actions/runs/28809261039/job/85432641504). The crash happens during the java-kotlin `analyze` step, right after "Resolving data extensions".

## Root cause

`java/lib/qlpack.yml` hard-pinned `githubsecuritylab/codeql-java-extensions: '0.2.1'` as a dependency. All three published configs *also* list `githubsecuritylab/codeql-java-extensions` directly in their `packs:` list (to load its MaD data extension models). This means the same pack gets resolved twice in a single evaluation:

- transitively: `codeql-java-queries` → `codeql-java-libs` → `codeql-java-extensions`
- directly: from the config's `packs:` list

The CodeQL CLI can't reconcile the two resolved instances of the same named pack and fatally errors.

**Why only Java is affected:** `csharp/lib/qlpack.yml` only depends on `codeql/csharp-all` — `codeql-csharp-extensions` is *not* baked into `csharp-libs`, it's purely opt-in via config, same as every other language. Java is the only lib pack that hard-pinned its extensions pack as a dependency (added in #8f4ee8a, "feat: add utility predicates and classes for Java library").

Nothing in `java/lib` actually needs `codeql-java-extensions` at QL-compile time: `java/lib/ghsl/Utils.qll` only imports standard `semmle.code.java.*` library modules. The extensions pack is a pure MaD data pack (see `java/ext/qlpack.yml`) with no QL code to import — the dependency existed only to bundle/pull in the pack, which is redundant since every shipped config already lists it explicitly.

## Fix

- Remove the `githubsecuritylab/codeql-java-extensions: '0.2.1'` line from `java/lib/qlpack.yml`'s `dependencies:`, bringing Java in line with C# (and every other language) where the extensions pack is purely opt-in via config.
- Bump `java/lib` version to `0.2.3` (see stacking note above re: why not `0.2.2`) so the fix gets published (`.github/workflows/publish.yml` compares each pack's `qlpack.yml` version against what's already published on GHCR, independently per pack).

No other `qlpack.yml` under `java/` needs changes:
- `java/src/qlpack.yml` depends on `githubsecuritylab/codeql-java-libs: '*'`, unaffected.
- `java/test/qlpack.yml` intentionally keeps its own direct `githubsecuritylab/codeql-java-extensions: '*'` dependency (for testing the extension models directly) — untouched.
- `java/ext/qlpack.yml` (the extensions pack itself) is unchanged.

Lock files (`codeql-pack.lock.yml`) don't need updating — they only record resolved *published-registry* packs (e.g. `codeql/java-all`); local in-workspace packs like `codeql-java-libs`/`codeql-java-extensions` are resolved via `codeql-workspace.yml` and never appeared in the lock files, so removing this dependency doesn't change lock content.

## Verification

Local sandbox only had CodeQL CLI 2.25.6 available, not the repo's pinned 2.21.1 (`.codeqlversion`), so local results can't perfectly reproduce or validate against the exact pinned toolchain:

- Compiled representative Java queries (including ones importing `java/lib/ghsl.qll`) with `codeql query compile` — succeeds cleanly after the fix, no dependency/syntax errors.
- Ran a subset of the Java test suite (`codeql test run`) — passing.
- Attempted to locally reproduce the exact duplicate-pack crash using local workspace pack resolution (`--additional-packs`); this didn't reproduce because local resolution dedupes identical filesystem paths, whereas the production failure occurs when the registry resolves the same named pack into two distinct locations (once as a transitive dependency, once as a directly-requested config pack).

**This repo's CI (`.github/workflows/ci.yml`) installs the actual pinned 2.21.1 CLI and runs the real Java analyze/compile/test jobs — that run is the authoritative validation of this fix**, since it uses the correct pinned toolchain rather than the newer, mismatched local CLI.
