### PR TITLE
Sync all packs to 0.2.2 and make .release.yml the version source of truth

### DIFF
--- a/.release.yml
+++ b/.release.yml
@@ -11,8 +11,10 @@ locations:
   - name: "CodeQL Pack Versions"
     paths:
       - "**/qlpack.yml"
+    excludes:
+      - "ql/hotspots/"
     patterns:
-      - '^version:\s*{version}'
+      - '^version:\s*{version}$'
   - name: "CodeQL Configurations"
     paths:
       - "configs/*.yml"

--- a/.release.yml
+++ b/.release.yml
@@ -1,6 +1,6 @@
 name: "CodeQL Community Packs"
 repository: "githubsecuritylab/codeql-community-packs"
-version: "0.2.0"
+version: "0.2.2"
 
 ecosystem: CodeQL
 excludes:
@@ -8,6 +8,11 @@ excludes:
   - "/codeql/"
 
 locations:
+  - name: "CodeQL Pack Versions"
+    paths:
+      - "**/qlpack.yml"
+    patterns:
+      - '^version:\s*{version}'
   - name: "CodeQL Configurations"
     paths:
       - "configs/*.yml"

--- a/cpp/lib/qlpack.yml
+++ b/cpp/lib/qlpack.yml
@@ -1,5 +1,5 @@
 library: true 
 name: githubsecuritylab/codeql-cpp-libs
-version: 0.2.1
+version: 0.2.2
 dependencies:
   codeql/cpp-all: '*'

--- a/cpp/src/qlpack.yml
+++ b/cpp/src/qlpack.yml
@@ -1,6 +1,6 @@
 library: false
 name: githubsecuritylab/codeql-cpp-queries
-version: 0.2.1
+version: 0.2.2
 suites: suites
 defaultSuiteFile: suites/cpp.qls
 dependencies:

--- a/cpp/src/qlpack.yml
+++ b/cpp/src/qlpack.yml
@@ -6,4 +6,4 @@ defaultSuiteFile: suites/cpp.qls
 dependencies:
   codeql/cpp-all: '*'
   codeql/cpp-queries: '*'
-  githubsecuritylab/codeql-cpp-libs: 0.2.0
+  githubsecuritylab/codeql-cpp-libs: '*'

--- a/csharp/ext-library-sources/qlpack.yml
+++ b/csharp/ext-library-sources/qlpack.yml
@@ -1,6 +1,6 @@
 library: true
 name: githubsecuritylab/codeql-csharp-library-sources
-version: 0.2.1
+version: 0.2.2
 extensionTargets:
   codeql/csharp-all: '*'
 dataExtensions:

--- a/csharp/ext/qlpack.yml
+++ b/csharp/ext/qlpack.yml
@@ -1,6 +1,6 @@
 library: true
 name: githubsecuritylab/codeql-csharp-extensions
-version: 0.2.1
+version: 0.2.2
 extensionTargets:
   codeql/csharp-all: '*'
 dataExtensions:

--- a/csharp/lib/qlpack.yml
+++ b/csharp/lib/qlpack.yml
@@ -1,5 +1,5 @@
 library: true 
 name: githubsecuritylab/codeql-csharp-libs
-version: 0.2.1
+version: 0.2.2
 dependencies:
   codeql/csharp-all: "*"

--- a/csharp/src/qlpack.yml
+++ b/csharp/src/qlpack.yml
@@ -1,6 +1,6 @@
 library: false
 name: githubsecuritylab/codeql-csharp-queries
-version: 0.2.1
+version: 0.2.2
 suites: suites
 defaultSuiteFile: suites/csharp.qls
 dependencies:

--- a/go/ext/qlpack.yml
+++ b/go/ext/qlpack.yml
@@ -1,6 +1,6 @@
 library: true
 name: githubsecuritylab/codeql-go-extensions
-version: 0.2.1
+version: 0.2.2
 extensionTargets:
   codeql/go-all: '*'
 dataExtensions:

--- a/go/lib/qlpack.yml
+++ b/go/lib/qlpack.yml
@@ -1,5 +1,5 @@
 library: true 
 name: githubsecuritylab/codeql-go-libs
-version: 0.2.1
+version: 0.2.2
 dependencies:
   codeql/go-all: '*'

--- a/go/src/qlpack.yml
+++ b/go/src/qlpack.yml
@@ -1,6 +1,6 @@
 library: false
 name: githubsecuritylab/codeql-go-queries
-version: 0.2.1
+version: 0.2.2
 suites: suites
 defaultSuiteFile: suites/go.qls
 dependencies:

--- a/go/src/qlpack.yml
+++ b/go/src/qlpack.yml
@@ -5,4 +5,4 @@ suites: suites
 defaultSuiteFile: suites/go.qls
 dependencies:
   codeql/go-all: '*'
-  githubsecuritylab/codeql-go-libs: 0.2.0
+  githubsecuritylab/codeql-go-libs: '*'

--- a/java/ext-library-sources/qlpack.yml
+++ b/java/ext-library-sources/qlpack.yml
@@ -1,6 +1,6 @@
 library: true
 name: githubsecuritylab/codeql-java-library-sources
-version: 0.2.1
+version: 0.2.2
 extensionTargets:
   codeql/java-all: '*'
 dataExtensions:

--- a/java/ext/qlpack.yml
+++ b/java/ext/qlpack.yml
@@ -1,6 +1,6 @@
 library: true
 name: githubsecuritylab/codeql-java-extensions
-version: 0.2.1
+version: 0.2.2
 extensionTargets:
   codeql/java-all: '*'
 dataExtensions:

--- a/java/lib/qlpack.yml
+++ b/java/lib/qlpack.yml
@@ -1,6 +1,6 @@
 library: true 
 name: githubsecuritylab/codeql-java-libs
-version: 0.2.1
+version: 0.2.2
 dependencies:
   codeql/java-all: '*'
   githubsecuritylab/codeql-java-extensions: '0.2.1'

--- a/java/lib/qlpack.yml
+++ b/java/lib/qlpack.yml
@@ -3,4 +3,4 @@ name: githubsecuritylab/codeql-java-libs
 version: 0.2.2
 dependencies:
   codeql/java-all: '*'
-  githubsecuritylab/codeql-java-extensions: '0.2.1'
+  githubsecuritylab/codeql-java-extensions: '*'

--- a/javascript/lib/qlpack.yml
+++ b/javascript/lib/qlpack.yml
@@ -1,5 +1,5 @@
 library: true
 name: githubsecuritylab/codeql-javascript-libs
-version: 0.2.1
+version: 0.2.2
 dependencies:
   codeql/javascript-all: '*'

--- a/javascript/src/qlpack.yml
+++ b/javascript/src/qlpack.yml
@@ -1,6 +1,6 @@
 library: false
 name: githubsecuritylab/codeql-javascript-queries
-version: 0.2.1
+version: 0.2.2
 suites: suites
 defaultSuiteFile: suites/javascript.qls
 dependencies:

--- a/javascript/src/qlpack.yml
+++ b/javascript/src/qlpack.yml
@@ -5,4 +5,4 @@ suites: suites
 defaultSuiteFile: suites/javascript.qls
 dependencies:
   codeql/javascript-all: '*'
-  githubsecuritylab/codeql-javascript-libs: 0.2.0
+  githubsecuritylab/codeql-javascript-libs: '*'

--- a/python/ext/qlpack.yml
+++ b/python/ext/qlpack.yml
@@ -1,6 +1,6 @@
 library: true
 name: githubsecuritylab/codeql-python-extensions
-version: 0.2.1
+version: 0.2.2
 extensionTargets:
   codeql/python-all: '*'
 dataExtensions:

--- a/python/lib/qlpack.yml
+++ b/python/lib/qlpack.yml
@@ -1,5 +1,5 @@
 library: true 
 name: githubsecuritylab/codeql-python-libs
-version: 0.2.1
+version: 0.2.2
 dependencies:
   codeql/python-all: '*'

--- a/python/src/qlpack.yml
+++ b/python/src/qlpack.yml
@@ -1,6 +1,6 @@
 library: false
 name: githubsecuritylab/codeql-python-queries
-version: 0.2.1
+version: 0.2.2
 suites: suites
 defaultSuiteFile: suites/python.qls
 dependencies:

--- a/python/src/qlpack.yml
+++ b/python/src/qlpack.yml
@@ -5,4 +5,4 @@ suites: suites
 defaultSuiteFile: suites/python.qls
 dependencies:
   codeql/python-all: '*'
-  githubsecuritylab/codeql-python-libs: 0.2.0
+  githubsecuritylab/codeql-python-libs: '*'

--- a/ruby/lib/qlpack.yml
+++ b/ruby/lib/qlpack.yml
@@ -1,5 +1,5 @@
 library: true 
 name: githubsecuritylab/codeql-ruby-libs
-version: 0.2.1
+version: 0.2.2
 dependencies:
   codeql/ruby-all: '*'

--- a/ruby/src/qlpack.yml
+++ b/ruby/src/qlpack.yml
@@ -1,6 +1,6 @@
 library: false
 name: githubsecuritylab/codeql-ruby-queries
-version: 0.2.1
+version: 0.2.2
 suites: suites
 defaultSuiteFile: suites/ruby.qls
 dependencies:

--- a/ruby/src/qlpack.yml
+++ b/ruby/src/qlpack.yml
@@ -5,4 +5,4 @@ suites: suites
 defaultSuiteFile: suites/ruby.qls
 dependencies:
   codeql/ruby-all: '*'
-  githubsecuritylab/codeql-ruby-libs: 0.2.0
+  githubsecuritylab/codeql-ruby-libs: '*'


### PR DESCRIPTION
## What this does

**1. Finishes the 0.2.2 sync (manual, one-time)**

Bumps the 16 remaining `qlpack.yml` files from `0.2.1` to `0.2.2` (`java/src` was already bumped separately and is untouched). All 18 published packs will land on a single, consistent `0.2.2` once this merges and `publish.yml` republishes them from the `v2.21.1`-era content already on `main` (dependency lock files were already refreshed in earlier PRs, this just flips the version that triggers the republish).

**2. Wires up `.release.yml` as the real master version**

`.release.yml` (driven by `update-release.yml`'s manual dispatch, via `42ByteLabs/patch-release-me`) was supposed to be a single point of truth for versions, but it was stale at `0.2.0` and, on closer look, **both its existing `locations` patterns currently match zero files**:
- The `configs/*.yml` pattern expects `owner/codeql-lang-queries@version`, but configs reference packs unversioned today.
- The `**/qlpack.yml` libs-dependency pattern expects a pinned version, but every pack now depends on its sibling libs pack via `"*"`.

So running `update-release.yml` today would only bump the number inside `.release.yml` itself, with no other effect.

This PR adds a third location, `CodeQL Pack Versions`, matching each pack's own top-level `version:` field (the one `publish.yml` actually diffs against GHCR), and bumps `.release.yml`'s version to `0.2.2` to match the now-synced reality.

Going forward, a single `update-release.yml` dispatch (patch/minor/major) will bump `.release.yml` and every pack's `qlpack.yml` version together in one PR, which is what actually triggers `publish.yml` to republish.

## Why one PR

`patch-release-me` does exact old-version → new-version string replacement, not "force to X", so it only works cleanly from a uniform baseline. Bumping the stragglers to `0.2.2` and pointing `.release.yml` at `0.2.2` in the same change keeps that baseline consistent from the start, with `java/src` (already `0.2.2`, left untouched) serving as a live check that the new location doesn't misfire on a pack that's already at the target version.

## Fixed during review: stale internal dependency pins

A review comment on `java/lib`'s `codeql-java-extensions` pin (stale at `0.2.1`) turned up a wider, pre-existing bug: `cpp/src`, `go/src`, `ruby/src`, `javascript/src`, and `python/src` all pinned their sibling `lib` dependency at a fixed version that had never been bumped since the packs were created (`cpp/src` was still on `0.2.0`, two releases behind). `csharp/src`, `java/src`, and every `test/qlpack.yml` in the repo already use `'*'` for this same kind of dependency, so the fixed pins were the outlier, not the convention.

All six were switched to `'*'` in `d0b969e`:
- `java/lib` -> `codeql-java-extensions`
- `cpp/src`, `go/src`, `ruby/src`, `javascript/src`, `python/src` -> their respective `-libs` packs

Implications:
- Inside this repo's own CI and local dev, no behavior change. The actual lock files (e.g. `cpp/src/codeql-pack.lock.yml`) never contain these sibling `githubsecuritylab/*` dependencies at all. They resolve locally by workspace path (`lib` is installed right before `src` in `ci.yml`), so the pinned version string was inert for local builds, which is exactly why the drift went unnoticed for so long.
- For external consumers pulling a published pack standalone from GHCR, this did matter: anyone installing `codeql-cpp-queries` was also pinned to `codeql-cpp-libs@0.2.0` via the registry, two releases stale, so lib fixes shipped in `0.2.1`/`0.2.2` never reached them. `'*'` fixes that going forward.
- Trade-off: there's no more explicit pin, so a breaking change in a `-libs` pack would flow to its `-queries` pack automatically with no compatibility gate. Since these packs are always version-bumped together as one release train and never intentionally diverged, the old pin wasn't real protection, just drift nobody had caught.
- Also needed for `.release.yml`'s new location to stay meaningful going forward: it only patches each pack's own top-level `version:` field, so a leftover fixed dependency pin would have kept drifting with nothing left to fix it.

Two smaller review fixes in the same commit:
- Anchored the new `.release.yml` pattern with a trailing `$` so a future bump (e.g. from `0.2.2`) can't partially match `0.2.20`.
- Excluded `ql/hotspots/` from that pattern (it's a separate package published via its own `workflow_dispatch` version input, not part of this pack family), and bumped `go/ext`/`python/ext` to `0.2.2` for baseline consistency (they aren't in `publish.yml`'s matrix yet, so this is a no-op for publishing today).

## Not in scope here

- Bumping the CodeQL CLI itself (`.codeqlversion` stays pinned at `v2.21.1`).
- Automating future bumps end-to-end (scheduling `update-release.yml`, detecting new CLI releases, etc.). That's the next layer, tracked separately.
