### PR TITLE
chore: bump remaining packs to 0.2.3 to match .release.yml

### DIFF
--- a/cpp/lib/qlpack.yml
+++ b/cpp/lib/qlpack.yml
@@ -1,5 +1,5 @@
 library: true 
 name: githubsecuritylab/codeql-cpp-libs
-version: 0.2.2
+version: 0.2.3
 dependencies:
   codeql/cpp-all: '*'

--- a/cpp/src/qlpack.yml
+++ b/cpp/src/qlpack.yml
@@ -1,6 +1,6 @@
 library: false
 name: githubsecuritylab/codeql-cpp-queries
-version: 0.2.2
+version: 0.2.3
 suites: suites
 defaultSuiteFile: suites/cpp.qls
 dependencies:

--- a/csharp/ext-library-sources/qlpack.yml
+++ b/csharp/ext-library-sources/qlpack.yml
@@ -1,6 +1,6 @@
 library: true
 name: githubsecuritylab/codeql-csharp-library-sources
-version: 0.2.2
+version: 0.2.3
 extensionTargets:
   codeql/csharp-all: '*'
 dataExtensions:

--- a/csharp/ext/qlpack.yml
+++ b/csharp/ext/qlpack.yml
@@ -1,6 +1,6 @@
 library: true
 name: githubsecuritylab/codeql-csharp-extensions
-version: 0.2.2
+version: 0.2.3
 extensionTargets:
   codeql/csharp-all: '*'
 dataExtensions:

--- a/csharp/lib/qlpack.yml
+++ b/csharp/lib/qlpack.yml
@@ -1,5 +1,5 @@
 library: true 
 name: githubsecuritylab/codeql-csharp-libs
-version: 0.2.2
+version: 0.2.3
 dependencies:
   codeql/csharp-all: "*"

--- a/csharp/src/qlpack.yml
+++ b/csharp/src/qlpack.yml
@@ -1,6 +1,6 @@
 library: false
 name: githubsecuritylab/codeql-csharp-queries
-version: 0.2.2
+version: 0.2.3
 suites: suites
 defaultSuiteFile: suites/csharp.qls
 dependencies:

--- a/go/ext/qlpack.yml
+++ b/go/ext/qlpack.yml
@@ -1,6 +1,6 @@
 library: true
 name: githubsecuritylab/codeql-go-extensions
-version: 0.2.2
+version: 0.2.3
 extensionTargets:
   codeql/go-all: '*'
 dataExtensions:

--- a/go/lib/qlpack.yml
+++ b/go/lib/qlpack.yml
@@ -1,5 +1,5 @@
 library: true 
 name: githubsecuritylab/codeql-go-libs
-version: 0.2.2
+version: 0.2.3
 dependencies:
   codeql/go-all: '*'

--- a/go/src/qlpack.yml
+++ b/go/src/qlpack.yml
@@ -1,6 +1,6 @@
 library: false
 name: githubsecuritylab/codeql-go-queries
-version: 0.2.2
+version: 0.2.3
 suites: suites
 defaultSuiteFile: suites/go.qls
 dependencies:

--- a/java/ext-library-sources/qlpack.yml
+++ b/java/ext-library-sources/qlpack.yml
@@ -1,6 +1,6 @@
 library: true
 name: githubsecuritylab/codeql-java-library-sources
-version: 0.2.2
+version: 0.2.3
 extensionTargets:
   codeql/java-all: '*'
 dataExtensions:

--- a/java/ext/qlpack.yml
+++ b/java/ext/qlpack.yml
@@ -1,6 +1,6 @@
 library: true
 name: githubsecuritylab/codeql-java-extensions
-version: 0.2.2
+version: 0.2.3
 extensionTargets:
   codeql/java-all: '*'
 dataExtensions:

--- a/java/src/qlpack.yml
+++ b/java/src/qlpack.yml
@@ -1,6 +1,6 @@
 library: false
 name: githubsecuritylab/codeql-java-queries
-version: 0.2.2
+version: 0.2.3
 suites: suites
 defaultSuiteFile: suites/java.qls
 dependencies:

--- a/javascript/lib/qlpack.yml
+++ b/javascript/lib/qlpack.yml
@@ -1,5 +1,5 @@
 library: true
 name: githubsecuritylab/codeql-javascript-libs
-version: 0.2.2
+version: 0.2.3
 dependencies:
   codeql/javascript-all: '*'

--- a/javascript/src/qlpack.yml
+++ b/javascript/src/qlpack.yml
@@ -1,6 +1,6 @@
 library: false
 name: githubsecuritylab/codeql-javascript-queries
-version: 0.2.2
+version: 0.2.3
 suites: suites
 defaultSuiteFile: suites/javascript.qls
 dependencies:

--- a/python/ext/qlpack.yml
+++ b/python/ext/qlpack.yml
@@ -1,6 +1,6 @@
 library: true
 name: githubsecuritylab/codeql-python-extensions
-version: 0.2.2
+version: 0.2.3
 extensionTargets:
   codeql/python-all: '*'
 dataExtensions:

--- a/python/lib/qlpack.yml
+++ b/python/lib/qlpack.yml
@@ -1,5 +1,5 @@
 library: true 
 name: githubsecuritylab/codeql-python-libs
-version: 0.2.2
+version: 0.2.3
 dependencies:
   codeql/python-all: '*'

--- a/python/src/qlpack.yml
+++ b/python/src/qlpack.yml
@@ -1,6 +1,6 @@
 library: false
 name: githubsecuritylab/codeql-python-queries
-version: 0.2.2
+version: 0.2.3
 suites: suites
 defaultSuiteFile: suites/python.qls
 dependencies:

--- a/ruby/lib/qlpack.yml
+++ b/ruby/lib/qlpack.yml
@@ -1,5 +1,5 @@
 library: true 
 name: githubsecuritylab/codeql-ruby-libs
-version: 0.2.2
+version: 0.2.3
 dependencies:
   codeql/ruby-all: '*'

--- a/ruby/src/qlpack.yml
+++ b/ruby/src/qlpack.yml
@@ -1,6 +1,6 @@
 library: false
 name: githubsecuritylab/codeql-ruby-queries
-version: 0.2.2
+version: 0.2.3
 suites: suites
 defaultSuiteFile: suites/ruby.qls
 dependencies:


### PR DESCRIPTION
## Why

`.release.yml`'s `version:` was bumped straight to `0.2.3` directly on `main` (not via the `update-release.yml`/`patch-release-me` tool, and not via a per-pack bump), and `java/lib` was independently bumped to `0.2.3` by #155's fatal-crash hotfix. That left the repo in a "half-migrated" state: `.release.yml` claimed `0.2.3` but only 1 of 19 packs actually was.

## What this does

Bumps every remaining pack's own `qlpack.yml` `version:` from `0.2.2` → `0.2.3`, so this now matches `.release.yml` for real (`java/lib` already at `0.2.3` is untouched).

- All 17 packs currently wired into `publish.yml` (cpp, csharp, go, java, javascript, python, ruby — `src`/`lib`, plus `csharp`/`java` `ext`/`ext-library-sources`)
- Also `go/ext` and `python/ext` — not yet wired into `publish.yml`'s matrix (that's #144), but still matched by `.release.yml`'s "CodeQL Pack Versions" location pattern, so bumped here too for consistency.

## What happens after merge

`publish.yml` triggers on the merge push and does a real batch publish: every pack except `java/lib` (already live at `0.2.3`, so a no-op) will publish `0.2.3` to GHCR.

Co-authored-by: Copilot App <223556219+Copilot@users.noreply.github.com>