### PR TITLE
feat(update-codeql-version): add optional release_bump input to publish in the same PR

### DIFF
--- a/.github/workflows/update-codeql-version.yml
+++ b/.github/workflows/update-codeql-version.yml
@@ -195,7 +195,7 @@ jobs:
               echo '  (`update-release.yml`) to bump every pack'"'"'s `version:` in lockstep via'
               echo '  `.release.yml` and trigger the real batch publish.'
             fi
-          } > pr-body.md
+          } > "${{ runner.temp }}/pr-body.md"
 
       - name: Create Pull Request
         uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1 # v8.1.1
@@ -203,7 +203,7 @@ jobs:
           token: ${{ steps.get_workflow_token.outputs.token }}
           title: ${{ steps.pr_meta.outputs.title }}
           commit-message: ${{ steps.pr_meta.outputs.title }}
-          body-path: pr-body.md
+          body-path: "${{ runner.temp }}/pr-body.md"
           branch: "chore/update-codeql-cli-${{ steps.version.outputs.version }}"
           labels: "version"
           delete-branch: true

--- a/.github/workflows/update-codeql-version.yml
+++ b/.github/workflows/update-codeql-version.yml
@@ -3,13 +3,23 @@ name: Update CodeQL CLI Version
 # Bumps the pinned CodeQL CLI/library version (.codeqlversion) and refreshes every
 # pack's codeql-pack.lock.yml against it, then opens a PR with the result.
 #
-# This does NOT publish anything by itself and does NOT bump any pack's `version:`
+# By default this does NOT publish anything and does NOT bump any pack's `version:`
 # field - it only prepares the dependency-refresh half of the process documented in
 # CONTRIBUTING.md's "Updating the pinned CodeQL CLI/library version" section. A human
 # (or a delegated Copilot coding agent) still needs to fix any compilation/test
 # breakage the new CLI/library versions introduce before merging, and the existing
 # "CodeQL Update Release" workflow (update-release.yml) is still what bumps every
 # pack's version and triggers the real batch publish once this PR is merged.
+#
+# Optionally, set `release_bump` (patch/minor/major) to fold that release bump into
+# THIS SAME PR - it runs the same `patch-release-me` step update-release.yml uses,
+# which bumps `.release.yml`'s repo-wide version and propagates it to every pack's
+# own `version:` field, `configs/*.yml` references, and cross-pack `-libs` pins in
+# one pass. Since publish.yml's auto-trigger fires on any push to `main` that changes
+# `.release.yml`, merging this one combined PR is then enough to kick off the real
+# batch publish immediately - no separate "CodeQL Update Release" run needed
+# afterward. Leave `release_bump` empty (the default) to only refresh dependencies,
+# e.g. when you expect CI breakage that needs fixing before it's safe to publish.
 on:
   workflow_dispatch:
     inputs:
@@ -17,6 +27,11 @@ on:
         description: "New CodeQL CLI version to pin, e.g. 2.22.0 (a leading 'v' is fine too)"
         required: true
         type: string
+      release_bump:
+        description: "Optional: patch/minor/major - also bump the repo release version and every pack's version in this same PR to trigger a real publish on merge. Leave empty to only refresh dependencies (default)."
+        required: false
+        type: string
+        default: ""
 
 jobs:
   update-codeql-version:
@@ -40,6 +55,17 @@ jobs:
             exit 1
           fi
           echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+
+      - name: Validate release_bump input
+        id: release_bump
+        run: |
+          set -euo pipefail
+          BUMP="${{ inputs.release_bump }}"
+          if [[ -n "$BUMP" && ! "$BUMP" =~ ^(patch|minor|major)$ ]]; then
+            echo "::error::release_bump must be 'patch', 'minor', 'major', or empty - got: ${{ inputs.release_bump }}" >&2
+            exit 1
+          fi
+          echo "bump=$BUMP" >> "$GITHUB_OUTPUT"
 
       - name: Update .codeqlversion
         run: |
@@ -81,6 +107,21 @@ jobs:
             echo "::endgroup::"
           done
 
+      - name: Bump release version (optional)
+        if: steps.release_bump.outputs.bump != ''
+        uses: 42ByteLabs/patch-release-me@04ea0a696abfc3cfbdfadb279bd9c9dd0b1652a2 # 0.6.6
+        with:
+          mode: ${{ steps.release_bump.outputs.bump }}
+
+      - name: Determine new release version (if bumped)
+        id: release_version
+        if: steps.release_bump.outputs.bump != ''
+        run: |
+          set -euo pipefail
+          NEW_VERSION="$(grep -E '^version:' .release.yml | head -1 | sed -E 's/^version:[[:space:]]*"?([^"[:space:]]+)"?/\1/')"
+          echo "version=$NEW_VERSION" >> "$GITHUB_OUTPUT"
+          echo "Release version bumped to ${NEW_VERSION}"
+
       - name: Summarize changed files
         run: |
           {
@@ -96,39 +137,73 @@ jobs:
           app-id: ${{ secrets.SECLABS_APP_ID }}
           private-key: ${{ secrets.SECLABS_APP_KEY }}
 
+      - name: Build PR title and body
+        id: pr_meta
+        run: |
+          set -euo pipefail
+          if [[ -n "${{ steps.release_bump.outputs.bump }}" ]]; then
+            TITLE="chore: bump pinned CodeQL CLI to v${{ steps.version.outputs.version }} and release v${{ steps.release_version.outputs.version }}"
+          else
+            TITLE="chore: bump pinned CodeQL CLI to v${{ steps.version.outputs.version }}"
+          fi
+          echo "title=$TITLE" >> "$GITHUB_OUTPUT"
+
+          {
+            echo 'Automated CLI version bump, requested via the "Update CodeQL CLI Version"'
+            echo "workflow (\`workflow_dispatch\`, \`codeql_version: ${{ steps.version.outputs.version }}\`, \`release_bump: ${{ steps.release_bump.outputs.bump || '(none)' }}\`)."
+            echo
+            echo "This PR:"
+            echo '- Updates `.codeqlversion` to `'"${{ steps.version.outputs.version }}"'`.'
+            echo '- Pins every `codeql/<lang>-all` / `codeql/<lang>-queries` dependency across all'
+            echo '  `qlpack.yml` files to the exact version shipped in the official CodeQL Bundle'
+            echo '  for this CLI release (see `.github/scripts/pin-codeql-library-versions.sh`) -'
+            echo '  this keeps `codeql pack upgrade` from jumping those libraries to'
+            echo '  registry-latest instead of the version this CLI actually ships/tests against.'
+            echo '- Runs `codeql pack upgrade <dir>` for every pack directory to refresh its'
+            echo '  `codeql-pack.lock.yml` against the new CLI and pinned library versions.'
+            echo
+            if [[ -n "${{ steps.release_bump.outputs.bump }}" ]]; then
+              echo "- Also bumps the repo release version (\`${{ steps.release_bump.outputs.bump }}\`, via the same"
+              echo '  `patch-release-me` step `update-release.yml` uses) to `'"${{ steps.release_version.outputs.version }}"'`,'
+              echo "  propagating it to every pack's own \`version:\` field, \`configs/*.yml\`"
+              echo '  references, and cross-pack `-libs` pins.'
+              echo
+              echo '**Merging this PR triggers the real batch publish** - `publish.yml`'"'"'s'
+              echo 'auto-trigger fires on any push to `main` that changes `.release.yml`, which this'
+              echo 'PR does. No separate "CodeQL Update Release" run is needed.'
+              echo
+              echo 'Remaining steps (see CONTRIBUTING.md'"'"'s "Updating the pinned CodeQL CLI/library'
+              echo 'version" section):'
+              echo
+              echo '- [ ] Check CI on this PR - fix any compilation/test errors caused by upstream'
+              echo '  API changes. This is usually the hardest part; consider delegating it to a'
+              echo '  Copilot coding agent session pointed at this PR/branch.'
+              echo '- [ ] Update the "Supported CodeQL versions" table in CONTRIBUTING.md.'
+              echo '- [ ] Review and merge - this alone will trigger the real batch publish.'
+            else
+              echo '**This PR does not publish anything by itself** - no pack `version:` field is'
+              echo "bumped here, so \`publish.yml\`'s version-diff trigger won't fire for it yet."
+              echo 'Remaining steps (see CONTRIBUTING.md'"'"'s "Updating the pinned CodeQL CLI/library'
+              echo 'version" section):'
+              echo
+              echo '- [ ] Check CI on this PR - fix any compilation/test errors caused by upstream'
+              echo '  API changes. This is usually the hardest part; consider delegating it to a'
+              echo '  Copilot coding agent session pointed at this PR/branch.'
+              echo '- [ ] Update the "Supported CodeQL versions" table in CONTRIBUTING.md.'
+              echo '- [ ] Review and merge.'
+              echo '- [ ] Once merged, run the "CodeQL Update Release" workflow'
+              echo '  (`update-release.yml`) to bump every pack'"'"'s `version:` in lockstep via'
+              echo '  `.release.yml` and trigger the real batch publish.'
+            fi
+          } > pr-body.md
+
       - name: Create Pull Request
         uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1 # v8.1.1
         with:
           token: ${{ steps.get_workflow_token.outputs.token }}
-          title: "chore: bump pinned CodeQL CLI to v${{ steps.version.outputs.version }}"
-          commit-message: "chore: bump pinned CodeQL CLI to v${{ steps.version.outputs.version }}"
-          body: |
-            Automated CLI version bump, requested via the "Update CodeQL CLI Version"
-            workflow (`workflow_dispatch`, `codeql_version: ${{ steps.version.outputs.version }}`).
-
-            This PR:
-            - Updates `.codeqlversion` to `${{ steps.version.outputs.version }}`.
-            - Pins every `codeql/<lang>-all` / `codeql/<lang>-queries` dependency across all
-              `qlpack.yml` files to the exact version shipped in the official CodeQL Bundle
-              for this CLI release (see `.github/scripts/pin-codeql-library-versions.sh`) -
-              this keeps `codeql pack upgrade` from jumping those libraries to
-              registry-latest instead of the version this CLI actually ships/tests against.
-            - Runs `codeql pack upgrade <dir>` for every pack directory to refresh its
-              `codeql-pack.lock.yml` against the new CLI and pinned library versions.
-
-            **This PR does not publish anything by itself** - no pack `version:` field is
-            bumped here, so `publish.yml`'s version-diff trigger won't fire for it yet.
-            Remaining steps (see CONTRIBUTING.md's "Updating the pinned CodeQL CLI/library
-            version" section):
-
-            - [ ] Check CI on this PR - fix any compilation/test errors caused by upstream
-              API changes. This is usually the hardest part; consider delegating it to a
-              Copilot coding agent session pointed at this PR/branch.
-            - [ ] Update the "Supported CodeQL versions" table in CONTRIBUTING.md.
-            - [ ] Review and merge.
-            - [ ] Once merged, run the "CodeQL Update Release" workflow
-              (`update-release.yml`) to bump every pack's `version:` in lockstep via
-              `.release.yml` and trigger the real batch publish.
+          title: ${{ steps.pr_meta.outputs.title }}
+          commit-message: ${{ steps.pr_meta.outputs.title }}
+          body-path: pr-body.md
           branch: "chore/update-codeql-cli-${{ steps.version.outputs.version }}"
           labels: "version"
           delete-branch: true

--- a/.release.yml
+++ b/.release.yml
@@ -6,6 +6,7 @@ ecosystem: CodeQL
 excludes:
   - "/.codeql/"
   - "/codeql/"
+  - "/codeql_home/" # only present when run alongside update-codeql-version.yml, which downloads the CLI here
 
 locations:
   - name: "CodeQL Pack Versions"

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -219,16 +219,38 @@ coding agent) in the loop for the hard part — fixing whatever the new CLI brea
    of [#118][pr-118]'s original proposal, extended to also own the `.codeqlversion` bump and the
    exact-version pinning (not just a bare `codeql pack upgrade` loop) and to use a token that triggers
    CI.
-3. **Fix breakage and finish the checklist** — this PR does **not** publish anything by itself (no
-   pack `version:` field is touched), so there's no rush, but it still needs:
-   - [ ] Fix any compilation/test errors CI surfaces from upstream API changes (usually the
-         hardest part, see [#124][pr-124] for an example of what this can involve). Consider
-         delegating this step to a Copilot coding agent session pointed at the PR/branch.
-   - [ ] Update the "Supported CodeQL versions" table above.
-   - [ ] Review and merge.
-   - [ ] Once merged, run [`update-release.yml`][update-release-workflow] as described in
-         [Cutting a release](#cutting-a-release) below to bump every pack's `version:` in
-         lockstep and trigger the real batch publish.
+
+   By default this PR only refreshes dependencies and does not publish anything — that's the safest
+   choice when you expect CI breakage that needs fixing first (the normal case for a minor/major CLI
+   bump). If you're confident the bump is safe to publish as soon as CI is green (e.g. a same-series
+   CLI patch release with no expected breaking changes), you can also set the optional `release_bump`
+   input (`patch`/`minor`/`major`) on the same `workflow_dispatch` run. When set, this workflow runs
+   the same [`42ByteLabs/patch-release-me`][patch-release-me] step [`update-release.yml`][update-release-workflow]
+   uses, in this same run, folding a full [release bump](#cutting-a-release) — and everything that
+   comes with it (every pack's `version:` field, `configs/*.yml` references, and cross-pack `-libs`
+   pins) — into this one PR. Since [`publish.yml`][publish-workflow]'s auto-trigger fires on any push
+   to `main` that changes `.release.yml`, merging this combined PR is then enough by itself to kick
+   off the real batch publish — no separate `update-release.yml` run needed afterward. Leave
+   `release_bump` empty (the default) otherwise.
+3. **Fix breakage and finish the checklist** — the PR's own description tells you which checklist
+   applies, depending on whether you set `release_bump`:
+   - **Without `release_bump` (default)** — this PR does **not** publish anything by itself (no pack
+     `version:` field is touched), so there's no rush, but it still needs:
+     - [ ] Fix any compilation/test errors CI surfaces from upstream API changes (usually the
+           hardest part, see [#124][pr-124] for an example of what this can involve). Consider
+           delegating this step to a Copilot coding agent session pointed at the PR/branch.
+     - [ ] Update the "Supported CodeQL versions" table above.
+     - [ ] Review and merge.
+     - [ ] Once merged, run [`update-release.yml`][update-release-workflow] as described in
+           [Cutting a release](#cutting-a-release) below to bump every pack's `version:` in
+           lockstep and trigger the real batch publish.
+   - **With `release_bump` set** — merging this PR *is* the release; there's no separate follow-up
+     step:
+     - [ ] Fix any compilation/test errors CI surfaces from upstream API changes, same as above.
+     - [ ] Update the "Supported CodeQL versions" table above.
+     - [ ] Review and merge — this alone triggers the real batch publish and the same
+           `summary` job / GitHub Release upsert described in
+           [Cutting a release](#cutting-a-release) below.
 
 > [!NOTE]
 > <a id="ql-hotspots"></a>**Why `ql/hotspots` is excluded from the `codeql pack upgrade` loop:**


### PR DESCRIPTION
## What

Adds an optional `release_bump` input (`patch`/`minor`/`major`, default empty) to the `Update CodeQL CLI Version` workflow (`update-codeql-version.yml`).

- **Left empty (default)**: unchanged behavior — the workflow only bumps `.codeqlversion`, re-pins `codeql/*` library deps, and refreshes lock files. Nothing publishes.
- **Set to `patch`/`minor`/`major`**: the workflow additionally runs the same `42ByteLabs/patch-release-me` step `update-release.yml` uses, in this same run — bumping the repo release version and propagating it to every pack's own `version:` field, `configs/*.yml` references, and cross-pack `-libs` pins, all in the *same* PR as the CLI/library bump.

Since `publish.yml`'s auto-trigger fires on any push to `main` that changes `.release.yml`, merging this combined PR is then enough by itself to kick off the real batch publish — no separate `update-release.yml` run needed afterward. This is meant for the common case of a same-series CLI patch release expected to be low-risk (e.g. `2.21.4` → `2.21.5`); a minor/major CLI bump should probably still go through the two-step flow (fix breakage first, decide separately when to publish).

## Why

Requested after landing PR #163/#166 (the CLI 2.21.4 bump): today, safely publishing a CLI bump requires two separate `workflow_dispatch` runs (`update-codeql-version.yml` then `update-release.yml`) even when the maintainer already knows the bump is safe to publish immediately. This collapses that into one optional flag.

## Changes

- `.github/workflows/update-codeql-version.yml`:
  - New `release_bump` string input + validation step (must be empty/`patch`/`minor`/`major`).
  - New conditional `Bump release version (optional)` step (`42ByteLabs/patch-release-me`, same pinned version `update-release.yml` uses).
  - New step to read the newly-bumped release version out of `.release.yml`.
  - PR title/body are now built dynamically (`Build PR title and body` step, writing `pr-body.md`) so the PR clearly documents whether merging it will publish, and what's left to do either way.
- `.release.yml`: added `/codeql_home/` to `excludes` — defensive parity fix, since this new code path runs `patch-release-me` in a job where `codeql_home/` already exists (from the earlier `Setup CodeQL` step), a scenario `update-release.yml` run standalone never encountered.
- `CONTRIBUTING.md`: documents the new `release_bump` input and the combined-PR flow under "Updating the pinned CodeQL CLI/library version".

## Testing

- Extracted every `run:` step from the workflow YAML and validated with `bash -n` — all pass.
- Simulated the "Build PR title and body" step's shell logic locally (both with and without `release_bump` set) and confirmed the rendered PR title/body markdown is correct (proper backtick code-formatting, no stray backslashes, correct possessives) in both branches.
- Cross-checked permissions (`contents: read`) match `update-release.yml`'s existing, already-working use of the same `patch-release-me` action.
- Not yet live-tested via `workflow_dispatch` with `release_bump` set — plan to do that as a follow-up once this merges, using a low-risk patch-level CLI bump.

Co-authored-by: Copilot App <223556219+Copilot@users.noreply.github.com>