### PR TITLE
fix(release): repin patch-release-me to 0.6.5 (0.6.6's GHCR image was never published)

### DIFF
--- a/.github/workflows/update-codeql-version.yml
+++ b/.github/workflows/update-codeql-version.yml
@@ -109,7 +109,7 @@ jobs:
 
       - name: Bump release version (optional)
         if: steps.release_bump.outputs.bump != ''
-        uses: 42ByteLabs/patch-release-me@04ea0a696abfc3cfbdfadb279bd9c9dd0b1652a2 # 0.6.6
+        uses: 42ByteLabs/patch-release-me@431a82795eda94d09b3821da9391c53ab287e84d # 0.6.5 (0.6.6's ghcr.io image was never published; action.yml is byte-identical between the two)
         with:
           mode: ${{ steps.release_bump.outputs.bump }}
 

--- a/.github/workflows/update-release.yml
+++ b/.github/workflows/update-release.yml
@@ -31,7 +31,7 @@ jobs:
           private-key: ${{ secrets.SECLABS_APP_KEY }}
 
       - name: "Patch Release Me"
-        uses: 42ByteLabs/patch-release-me@04ea0a696abfc3cfbdfadb279bd9c9dd0b1652a2 # 0.6.6
+        uses: 42ByteLabs/patch-release-me@431a82795eda94d09b3821da9391c53ab287e84d # 0.6.5 (0.6.6's ghcr.io image was never published; see https://github.com/42ByteLabs/patch-release-me/issues - action.yml is byte-identical between the two)
         with:
           # Bump (patch)
           mode: ${{ inputs.mode }}


### PR DESCRIPTION
## What broke

Dispatching `update-release.yml` (`mode: patch`) just now to publish the CLI 2.21.4 bump failed immediately:

```
#2 [internal] load metadata for ghcr.io/42bytelabs/patch-release-me:0.6.6
#2 ERROR: ghcr.io/42bytelabs/patch-release-me:0.6.6: not found
ERROR: failed to build: failed to solve: ghcr.io/42bytelabs/patch-release-me:0.6.6: failed to resolve source metadata ...: not found
```

Confirmed the root cause is upstream: `42ByteLabs/patch-release-me`'s `0.6.6` git tag/release exists (published 2026-05-25), but the corresponding container image was apparently never pushed to GHCR. Verified via an anonymous GHCR registry API query (`GET https://ghcr.io/v2/42bytelabs/patch-release-me/tags/list`) — only `0.6.5` and earlier tags actually exist as real images; `0.6.6`/`v0.6.6` are absent.

This broke **both** workflows that use this action, since both pinned the `0.6.6` commit SHA:
- `update-release.yml` (pre-existing, unrelated to recent work here)
- `update-codeql-version.yml`'s new optional `release_bump` step (#167, merged today)

## Fix

Repin both to `0.6.5`'s commit SHA (`431a82795eda94d09b3821da9391c53ab287e84d`), which does have a real, pullable image. Confirmed `action.yml` is byte-identical between `0.6.5` and `0.6.6` (same blob SHA via the GitHub API) — same `mode` input, same Docker entrypoint/args — so this is a safe, no-behavior-change repin, not a downgrade in functionality.

## Verification

- `gh api repos/42ByteLabs/patch-release-me/git/refs/tags/0.6.5` → confirms the commit SHA.
- Anonymous GHCR tag listing confirms `0.6.5`/`v0.6.5` images exist; `0.6.6`/`v0.6.6` do not.
- `action.yml` content (via GitHub API blob SHA) is identical at both refs.

## Next step after merge

Re-dispatch `update-release.yml` (`mode: patch`) to actually publish the pending CLI 2.21.4 changes.

Co-authored-by: Copilot App <223556219+Copilot@users.noreply.github.com>