### PR TITLE
fix(release): invoke patch-release-me via docker run to avoid mode arg quoting bug

### DIFF
--- a/.github/workflows/update-codeql-version.yml
+++ b/.github/workflows/update-codeql-version.yml
@@ -123,11 +123,14 @@ jobs:
           # Running the same pinned image ourselves via a normal shell `run:`
           # step naturally splits `-m` and the mode value into separate argv
           # entries, avoiding the bug entirely.
+          #
+          # Pinned by digest (not just tag) so the exact image content can't
+          # change out from under us - digest corresponds to the 0.6.5 tag.
           docker run --rm \
             --user "$(id -u):$(id -g)" \
             -v "${{ github.workspace }}:/repo" \
             -w /repo \
-            ghcr.io/42bytelabs/patch-release-me:0.6.5 \
+            ghcr.io/42bytelabs/patch-release-me@sha256:d9d7abe7051855d0c395fec99d931acc002fb6b299ca16b8123e2c8ef0c7e750 \
             --disable-banner bump -m ${{ steps.release_bump.outputs.bump }}
 
       - name: Determine new release version (if bumped)

--- a/.github/workflows/update-codeql-version.yml
+++ b/.github/workflows/update-codeql-version.yml
@@ -109,9 +109,26 @@ jobs:
 
       - name: Bump release version (optional)
         if: steps.release_bump.outputs.bump != ''
-        uses: 42ByteLabs/patch-release-me@431a82795eda94d09b3821da9391c53ab287e84d # 0.6.5 (0.6.6's ghcr.io image was never published; action.yml is byte-identical between the two)
-        with:
-          mode: ${{ steps.release_bump.outputs.bump }}
+        run: |
+          set -euo pipefail
+          # Invoke the pinned patch-release-me image directly via `docker run`
+          # instead of `uses: 42ByteLabs/patch-release-me@...`. That action's own
+          # action.yml builds its Docker CMD as a single YAML list item
+          # (`-m "${{ inputs.mode }}"`); Docker container actions don't go
+          # through a shell, so the literal quote characters end up baked into
+          # ONE argv token (`-m "minor"`). clap can't match that against
+          # "patch"/"minor"/"major" and silently falls back to its own default
+          # (Patch) - meaning `minor`/`major` have always quietly produced a
+          # patch bump instead (confirmed via a local repro: see PR history).
+          # Running the same pinned image ourselves via a normal shell `run:`
+          # step naturally splits `-m` and the mode value into separate argv
+          # entries, avoiding the bug entirely.
+          docker run --rm \
+            --user "$(id -u):$(id -g)" \
+            -v "${{ github.workspace }}:/repo" \
+            -w /repo \
+            ghcr.io/42bytelabs/patch-release-me:0.6.5 \
+            --disable-banner bump -m ${{ steps.release_bump.outputs.bump }}
 
       - name: Determine new release version (if bumped)
         id: release_version

--- a/.github/workflows/update-release.yml
+++ b/.github/workflows/update-release.yml
@@ -31,10 +31,26 @@ jobs:
           private-key: ${{ secrets.SECLABS_APP_KEY }}
 
       - name: "Patch Release Me"
-        uses: 42ByteLabs/patch-release-me@431a82795eda94d09b3821da9391c53ab287e84d # 0.6.5 (0.6.6's ghcr.io image was never published; see https://github.com/42ByteLabs/patch-release-me/issues - action.yml is byte-identical between the two)
-        with:
-          # Bump (patch)
-          mode: ${{ inputs.mode }}
+        run: |
+          set -euo pipefail
+          # Invoke the pinned patch-release-me image directly via `docker run`
+          # instead of `uses: 42ByteLabs/patch-release-me@...`. That action's own
+          # action.yml builds its Docker CMD as a single YAML list item
+          # (`-m "${{ inputs.mode }}"`); Docker container actions don't go
+          # through a shell, so the literal quote characters end up baked into
+          # ONE argv token (`-m "minor"`). clap can't match that against
+          # "patch"/"minor"/"major" and silently falls back to its own default
+          # (Patch) - meaning `minor`/`major` have always quietly produced a
+          # patch bump instead (confirmed via a local repro: see PR history).
+          # Running the same pinned image ourselves via a normal shell `run:`
+          # step naturally splits `-m` and the mode value into separate argv
+          # entries, avoiding the bug entirely.
+          docker run --rm \
+            --user "$(id -u):$(id -g)" \
+            -v "${{ github.workspace }}:/repo" \
+            -w /repo \
+            ghcr.io/42bytelabs/patch-release-me:0.6.5 \
+            --disable-banner bump -m ${{ inputs.mode }}
 
       - name: Create Pull Request
         uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1 # v8.1.1

--- a/.github/workflows/update-release.yml
+++ b/.github/workflows/update-release.yml
@@ -45,11 +45,13 @@ jobs:
           # Running the same pinned image ourselves via a normal shell `run:`
           # step naturally splits `-m` and the mode value into separate argv
           # entries, avoiding the bug entirely.
+          # Pinned by digest (not just tag) so the exact image content can't
+          # change out from under us - digest corresponds to the 0.6.5 tag.
           docker run --rm \
             --user "$(id -u):$(id -g)" \
             -v "${{ github.workspace }}:/repo" \
             -w /repo \
-            ghcr.io/42bytelabs/patch-release-me:0.6.5 \
+            ghcr.io/42bytelabs/patch-release-me@sha256:d9d7abe7051855d0c395fec99d931acc002fb6b299ca16b8123e2c8ef0c7e750 \
             --disable-banner bump -m ${{ inputs.mode }}
 
       - name: Create Pull Request


### PR DESCRIPTION
## Summary

Fixes a real, silent bug where `release_bump: minor` / `major` (in
`update-codeql-version.yml`) and `mode: minor` / `major` (in
`update-release.yml`) have always quietly produced a **patch** bump instead
of the requested one - discovered live while dispatching the CLI 2.22.4 /
`release_bump: minor` bump (intended `0.2.4` -> `0.3.0`, actually got
`0.2.4` -> `0.2.5`).

## Root cause

`42ByteLabs/patch-release-me`'s own `action.yml` builds its Docker `CMD` as a
single YAML list item:

```yaml
args:
  - bump
  - -m "${{ inputs.mode }}"
```

Docker container actions pass `args:` directly as the container command -
there's no shell in between to word-split or strip quotes. So this becomes
**one** argv token: `-m "minor"` (quote characters included, literally).
`clap`'s short-flag parsing then reads the mode value as `"minor"` (with the
quotes), which doesn't match any of the literal strings `"patch"` /
`"minor"` / `"major"` in the tool's `match`, so it silently falls through to
its own default arm, `BumpMode::Patch`.

This was invisible until now because **every prior dispatch used
`mode: patch`**, and `Patch` is also the tool's own silent fallback default -
so it "worked" by coincidence every time. The first time we asked for
`minor`, the bug surfaced.

Confirmed directly in the run log for the live dispatch:

```
mode: minor
-> Bumping version: Patch      <- should say "Minor"
```

And reproduced locally by pulling the exact pinned image
(`ghcr.io/42bytelabs/patch-release-me:0.6.5`) and running it directly:

```
$ docker run --rm -v ".:/repo" -w /repo ghcr.io/42bytelabs/patch-release-me:0.6.5 bump -m '"minor"'
-> Bumping version: Patch          # bug reproduced: 0.2.4 -> 0.2.5

$ docker run --rm -v ".:/repo" -w /repo ghcr.io/42bytelabs/patch-release-me:0.6.5 bump -m minor
-> Bumping version: Minor          # fixed: 0.2.4 -> 0.3.0
```

## Fix

Stop using `uses: 42ByteLabs/patch-release-me@<sha>` (the wrapping action)
for the bump step in both `update-release.yml` and
`update-codeql-version.yml`. Instead, invoke the exact same pinned image
(`ghcr.io/42bytelabs/patch-release-me:0.6.5`) ourselves via a plain `run:`
step:

```yaml
- name: "Patch Release Me"
  run: |
    docker run --rm \
      --user "$(id -u):$(id -g)" \
      -v "${{ github.workspace }}:/repo" \
      -w /repo \
      ghcr.io/42bytelabs/patch-release-me:0.6.5 \
      --disable-banner bump -m ${{ inputs.mode }}
```

A normal shell `run:` step naturally splits `-m` and the mode value into
separate argv entries (no embedded quotes), which sidesteps the bug
entirely without needing an upstream fix or a version bump of the pinned
tool. `--user "$(id -u):$(id -g)"` keeps files written by the container
owned by the runner user (avoids `root`-owned files / git "dubious
ownership" issues in the later PR-creation step).

## Testing

- Local repro + fix validation against the pinned `0.6.5` image (shown
  above), using a copy of this repo's actual `.release.yml`.
- Validated both updated workflow files parse as valid YAML.
- No other behavior changes: same pinned image/version, same underlying
  `patch-release-me` functionality, only the invocation mechanism changes.

## Related

- Discovered while acting on PR #170's dispatch
  (`codeql_version: 2.22.4`, `release_bump: minor`), which produced the
  wrong release version (`0.2.5` instead of `0.3.0`). That PR is being
  closed in favor of a fresh, correct dispatch once this fix is merged.
- Separately, `@felickz` also has an upstream PR open
  (42ByteLabs/patch-release-me#160) fixing why `0.6.6`'s container image was
  never published to GHCR in the first place (unrelated root cause, same
  tool).

Co-authored-by: Copilot App <223556219+Copilot@users.noreply.github.com>
