### PR TITLE
feat(release): add prerelease boolean toggle, default off

### DIFF
--- a/.github/scripts/upsert-release-table.sh
+++ b/.github/scripts/upsert-release-table.sh
@@ -27,6 +27,16 @@ if [ -z "$VERSION" ]; then
 fi
 TAG="v${VERSION}"
 
+# Whether the release should be marked as a pre-release. Set via the
+# `prerelease` (update-release.yml) / `release_prerelease`
+# (update-codeql-version.yml) workflow_dispatch input, which writes a
+# `prerelease: true|false` field into .release.yml alongside the version bump
+# (see those workflows). Defaults to false (a full release) if the field is
+# absent - e.g. for .release.yml files predating this field, or if the
+# version was bumped by some other means.
+PRERELEASE_FLAG=$(grep -E '^prerelease:' .release.yml | head -1 | sed -E 's/^prerelease:[[:space:]]*"?([^"[:space:]]*)"?/\1/' || true)
+PRERELEASE_FLAG="${PRERELEASE_FLAG:-false}"
+
 BLOCK_FILE=$(mktemp)
 {
   echo "$START_MARKER"
@@ -64,11 +74,15 @@ if gh release view "$TAG" >/dev/null 2>&1; then
 
   gh release edit "$TAG" --notes-file "$NEW_BODY"
 else
-  echo "Release $TAG does not exist yet; creating it as a pre-release."
-  gh release create "$TAG" \
-    --title "$TAG" \
-    --notes-file "$BLOCK_FILE" \
-    --generate-notes \
-    --prerelease \
+  echo "Release $TAG does not exist yet; creating it (prerelease: ${PRERELEASE_FLAG})."
+  CREATE_ARGS=(
+    --title "$TAG"
+    --notes-file "$BLOCK_FILE"
+    --generate-notes
     --target "${GITHUB_SHA:-main}"
+  )
+  if [ "$PRERELEASE_FLAG" = "true" ]; then
+    CREATE_ARGS+=(--prerelease)
+  fi
+  gh release create "$TAG" "${CREATE_ARGS[@]}"
 fi

--- a/.github/workflows/update-codeql-version.yml
+++ b/.github/workflows/update-codeql-version.yml
@@ -32,6 +32,11 @@ on:
         required: false
         type: string
         default: ""
+      release_prerelease:
+        description: "Only used if release_bump is set: mark the resulting GitHub Release as a pre-release (default: off, a full release)"
+        required: true
+        type: boolean
+        default: false
 
 jobs:
   update-codeql-version:
@@ -113,6 +118,20 @@ jobs:
         with:
           mode: ${{ steps.release_bump.outputs.bump }}
 
+      - name: Set release prerelease flag (optional)
+        if: steps.release_bump.outputs.bump != ''
+        run: |
+          set -euo pipefail
+          # See the matching step/comment in update-release.yml: patch-release-me's
+          # Config struct doesn't know about a `prerelease` key, so it would get
+          # silently dropped on the NEXT bump - harmless here since we always
+          # re-set it fresh right after this bump, before the PR is opened.
+          if grep -qE '^prerelease:' .release.yml; then
+            sed -i -E "s/^prerelease:.*/prerelease: ${{ inputs.release_prerelease }}/" .release.yml
+          else
+            sed -i -E "/^version:/a prerelease: ${{ inputs.release_prerelease }}" .release.yml
+          fi
+
       - name: Determine new release version (if bumped)
         id: release_version
         if: steps.release_bump.outputs.bump != ''
@@ -163,6 +182,11 @@ jobs:
             echo '  `codeql-pack.lock.yml` against the new CLI and pinned library versions.'
             echo
             if [[ -n "${{ steps.release_bump.outputs.bump }}" ]]; then
+              if [[ "${{ inputs.release_prerelease }}" == "true" ]]; then
+                RELEASE_KIND="pre-release"
+              else
+                RELEASE_KIND="full release"
+              fi
               echo "- Also bumps the repo release version (\`${{ steps.release_bump.outputs.bump }}\`, via the same"
               echo '  `patch-release-me` step `update-release.yml` uses) to `'"${{ steps.release_version.outputs.version }}"'`,'
               echo "  propagating it to every pack's own \`version:\` field, \`configs/*.yml\`"
@@ -170,7 +194,9 @@ jobs:
               echo
               echo '**Merging this PR triggers the real batch publish** - `publish.yml`'"'"'s'
               echo 'auto-trigger fires on any push to `main` that changes `.release.yml`, which this'
-              echo 'PR does. No separate "CodeQL Update Release" run is needed.'
+              echo "PR does. No separate \"CodeQL Update Release\" run is needed. That run's \`summary\`"
+              echo "job will create the matching GitHub Release as a **${RELEASE_KIND}**"
+              echo "(\`release_prerelease: ${{ inputs.release_prerelease }}\`)."
               echo
               echo 'Remaining steps (see CONTRIBUTING.md'"'"'s "Updating the pinned CodeQL CLI/library'
               echo 'version" section):'

--- a/.github/workflows/update-release.yml
+++ b/.github/workflows/update-release.yml
@@ -12,6 +12,11 @@ on:
           - patch
           - minor
           - major
+      prerelease:
+        description: "Mark the resulting GitHub Release as a pre-release (default: off, a full release)"
+        required: true
+        type: boolean
+        default: false
 
 jobs:
   update-release:
@@ -36,6 +41,22 @@ jobs:
           # Bump (patch)
           mode: ${{ inputs.mode }}
 
+      - name: Set release prerelease flag
+        run: |
+          set -euo pipefail
+          # patch-release-me's Config struct doesn't know about a `prerelease`
+          # key, so it silently drops any such field the next time it
+          # round-trips .release.yml (see config.rs: Config::write() re-
+          # serializes from the Rust struct, not the original file text).
+          # That's fine here since we always re-set it fresh on every dispatch,
+          # right after the bump step, before the PR is opened - so it's never
+          # stale by the time upsert-release-table.sh reads it.
+          if grep -qE '^prerelease:' .release.yml; then
+            sed -i -E "s/^prerelease:.*/prerelease: ${{ inputs.prerelease }}/" .release.yml
+          else
+            sed -i -E "/^version:/a prerelease: ${{ inputs.prerelease }}" .release.yml
+          fi
+
       - name: Create Pull Request
         uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1 # v8.1.1
         with:
@@ -44,6 +65,12 @@ jobs:
           commit-message: "[chore]: Auto Patch new Release"
           body: |
             This is automatically created as a chore to patch and update the release.
+
+            Requested via the "CodeQL Update Release" workflow (`workflow_dispatch`,
+            `mode: ${{ inputs.mode }}`, `prerelease: ${{ inputs.prerelease }}`).
+
+            Merging this PR triggers `publish.yml`'s real batch publish. Its `summary`
+            job will create the matching GitHub Release as a **${{ inputs.prerelease == 'true' && 'pre-release' || 'full release' }}**.
           branch: "auto-patch-release"
           labels: "version"
           delete-branch: true

--- a/.github/workflows/update-release.yml
+++ b/.github/workflows/update-release.yml
@@ -70,7 +70,7 @@ jobs:
             `mode: ${{ inputs.mode }}`, `prerelease: ${{ inputs.prerelease }}`).
 
             Merging this PR triggers `publish.yml`'s real batch publish. Its `summary`
-            job will create the matching GitHub Release as a **${{ inputs.prerelease == 'true' && 'pre-release' || 'full release' }}**.
+            job will create the matching GitHub Release as a **${{ inputs.prerelease && 'pre-release' || 'full release' }}**.
           branch: "auto-patch-release"
           labels: "version"
           delete-branch: true

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -224,8 +224,10 @@ coding agent) in the loop for the hard part — fixing whatever the new CLI brea
    choice when you expect CI breakage that needs fixing first (the normal case for a minor/major CLI
    bump). If you're confident the bump is safe to publish as soon as CI is green (e.g. a same-series
    CLI patch release with no expected breaking changes), you can also set the optional `release_bump`
-   input (`patch`/`minor`/`major`) on the same `workflow_dispatch` run. When set, this workflow runs
-   the same [`42ByteLabs/patch-release-me`][patch-release-me] step [`update-release.yml`][update-release-workflow]
+   input (`patch`/`minor`/`major`) on the same `workflow_dispatch` run (and, alongside it,
+   `release_prerelease` to control whether the resulting release is a pre-release — default off, see
+   the note in [Cutting a release](#cutting-a-release)). When set, this workflow runs the same
+   [`42ByteLabs/patch-release-me`][patch-release-me] step [`update-release.yml`][update-release-workflow]
    uses, in this same run, folding a full [release bump](#cutting-a-release) — and everything that
    comes with it (every pack's `version:` field, `configs/*.yml` references, and cross-pack `-libs`
    pins) — into this one PR. Since [`publish.yml`][publish-workflow]'s auto-trigger fires on any push
@@ -296,22 +298,38 @@ what actually triggers a real, atomic batch publish of every changed pack — th
 supported way to bump `.release.yml`:
 
 - [ ] Run [`update-release.yml`][update-release-workflow] (`workflow_dispatch`, pick
-      patch/minor/major). It runs the [`42ByteLabs/patch-release-me`][patch-release-me] tool, which
-      reads `.release.yml`'s current `version:`, computes the bump, and opens a PR that:
+      patch/minor/major, and optionally check `prerelease`). It runs the
+      [`42ByteLabs/patch-release-me`][patch-release-me] tool, which reads `.release.yml`'s current
+      `version:`, computes the bump, and opens a PR that:
   - bumps `.release.yml`'s `version:` to the new value, and
   - patches **every** matching pack's own `version:` field to match (the "CodeQL Pack Versions"
     location in `.release.yml`, added in [#158][pr-158] — this is what makes `.release.yml` a real
-    lever over publishing today, not just a changelog label).
+    lever over publishing today, not just a changelog label), and
+  - writes a `prerelease: true|false` field into `.release.yml` reflecting the `prerelease` input
+    (default `false`/unchecked, i.e. a full release) - see the note below.
 - [ ] Review and merge that PR like any other.
 - [ ] Merging it is what changes `.release.yml` on `main`, which auto-triggers
       [`publish.yml`][publish-workflow] for a real batch publish: every pack whose version actually
       changed gets published to [GHCR][ghcr-packages] in that one run.
 - [ ] The run's `summary` job posts two markdown tables to the job summary **and** upserts both into
-      the matching GitHub Release (`vX.Y.Z`), auto-creating it as a pre-release if it doesn't exist
-      yet: a publish summary (what published) and a CodeQL standard library & query pack versions
-      table (whether each language's locked `codeql/*` dependencies match what the pinned CodeQL CLI
-      actually ships upstream — see the note under
+      the matching GitHub Release (`vX.Y.Z`), creating it if it doesn't exist yet: a publish summary
+      (what published) and a CodeQL standard library & query pack versions table (whether each
+      language's locked `codeql/*` dependencies match what the pinned CodeQL CLI actually ships
+      upstream — see the note under
       [Updating the pinned CodeQL CLI/library version](#updating-the-pinned-codeql-clilibrary-version)).
+
+> [!NOTE]
+> **Pre-release vs. full release.** The GitHub Release created above is a **full release by
+> default** - `.github/scripts/upsert-release-table.sh` only passes `--prerelease` to
+> `gh release create` if `.release.yml`'s `prerelease:` field says `true`. That field is set by the
+> `prerelease` input on [`update-release.yml`][update-release-workflow] (default off) or the
+> `release_prerelease` input on [`update-codeql-version.yml`][update-codeql-version-workflow] (only
+> used when that workflow's `release_bump` is also set). It's re-written fresh on every dispatch,
+> immediately after the version bump and before the PR opens, so it always reflects that specific
+> dispatch's choice - `patch-release-me` doesn't know about this field and drops it the *next* time
+> it round-trips `.release.yml`, but that's harmless since we always re-set it right away. A
+> `.release.yml` predating this field (or a version bumped by some other means) defaults to `false`
+> (a full release).
 
 > [!WARNING]
 > **Never hand-edit `.release.yml`'s `version:` field directly** — `patch-release-me` computes its


### PR DESCRIPTION
## Decision

Every release cut so far has been marked as a **pre-release** on GitHub, regardless of intent - `upsert-release-table.sh` unconditionally passed `--prerelease` to `gh release create`. There was no way to cut a full release without hand-editing it after the fact.

## What this does

- `update-release.yml`: new `prerelease` `workflow_dispatch` boolean input, **default off** (full release).
- `update-codeql-version.yml`: new `release_prerelease` input, same default, only meaningful when `release_bump` is also set.
- Both write a `prerelease: true|false` field into `.release.yml` right after the version bump, before the PR opens.
- `upsert-release-table.sh` reads that field (defaults to `false` if absent - e.g. a `.release.yml` from before this change) and only adds `--prerelease` when it's `true`.
- `patch-release-me`'s `Config::write()` re-serializes `.release.yml` from its own struct on every bump, so unknown fields like `prerelease:` get silently dropped the *next* time it runs. That's fine - we always rewrite it fresh in the same run, immediately before the PR opens, so it's never read stale.
- `CONTRIBUTING.md` documents both inputs and the default-full-release behavior.

## Testing

- Both workflow YAML files validated with `yaml.safe_load`.
- `upsert-release-table.sh` syntax-checked with `bash -n` and exercised locally against all 4 scenarios (field present/absent, insert-if-missing, update-if-present) - all passed.

Not part of PR #171 (mode-arg-quoting + digest pinning) since this is an unrelated feature.
