### PR TITLE
fix(release): stop patch-release-me double-bumping ql/hotspots

### DIFF
--- a/.release.yml
+++ b/.release.yml
@@ -9,13 +9,13 @@ excludes:
   - "/codeql_home/" # only present when run alongside update-codeql-version.yml, which downloads the CLI here
 
 locations:
-  - name: "CodeQL Pack Versions"
+  - name: "CodeQL Packs" # must match patch-release-me's built-in default location name for the "CodeQL" ecosystem (see defaults.yml upstream) - otherwise BOTH run, and the built-in one bumps every qlpack.yml with no knowledge of our excludes below
     paths:
       - "**/qlpack.yml"
     excludes:
       - "ql/hotspots/"
     patterns:
-      - '^version:\s*{version}$'
+      - '(?m)^version:\s*{version}$' # (?m) is required: without it ^/$ anchor to the whole file, not each line, so this would never match a real multi-line qlpack.yml
   - name: "CodeQL Configurations"
     paths:
       - "configs/*.yml"

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -305,11 +305,23 @@ supported way to bump `.release.yml`:
       [`42ByteLabs/patch-release-me`][patch-release-me] tool, which reads `.release.yml`'s current
       `version:`, computes the bump, and opens a PR that:
   - bumps `.release.yml`'s `version:` to the new value, and
-  - patches **every** matching pack's own `version:` field to match (the "CodeQL Pack Versions"
+  - patches **every** matching pack's own `version:` field to match (the "CodeQL Packs"
     location in `.release.yml`, added in [#158][pr-158] — this is what makes `.release.yml` a real
     lever over publishing today, not just a changelog label), and
   - writes a `prerelease: true|false` field into `.release.yml` reflecting the `prerelease` input
     (default `false`/unchecked, i.e. a full release) - see the note below.
+
+> [!IMPORTANT]
+> `ql/hotspots/` is deliberately excluded from that "CodeQL Packs" location (it's a separate
+> package published by its own manual `workflow_dispatch`, not part of the per-language pack
+> family - see `.github/workflows/hotspots.yml`). That location's `name:` **must stay exactly
+> `"CodeQL Packs"`**, matching `patch-release-me`'s own built-in default location for the
+> `CodeQL` ecosystem - if it's ever renamed, the built-in default silently reactivates
+> alongside it and re-bumps `ql/hotspots/qlpack.yml` regardless of the exclude, since the
+> built-in default doesn't know about it. Its pattern also needs the `(?m)` multiline flag
+> (`(?m)^version:\s*{version}$`) - without it, `^`/`$` anchor to the whole file rather than each
+> line and the pattern silently never matches anything. Both were real, live bugs discovered
+> while landing the CodeQL 2.22.4/v0.3.0 bump (see PR #173).
 - [ ] Review and merge that PR like any other.
 - [ ] Merging it is what changes `.release.yml` on `main`, which auto-triggers
       [`publish.yml`][publish-workflow] for a real batch publish: every pack whose version actually


### PR DESCRIPTION
## Why

`ql/hotspots/` is deliberately excluded from `.release.yml`'s pack-version
location (added in #158/d0b969e - it's a separate package published by its
own manual `workflow_dispatch`, not part of the per-language pack family),
yet it kept getting bumped in lockstep with every release anyway (0.2.4 →
0.3.0 in #173, 0.2.1 → 0.2.4 in #169 before that).

## Root cause

Confirmed by running the exact pinned `patch-release-me` image locally with
`--debug`, against both a minimal repro and a full copy of this repo's real
`qlpack.yml` files:

1. **`patch-release-me` ships its own hardcoded default location** for the
   `CodeQL` ecosystem, literally named `"CodeQL Packs"` (see its
   `src/defaults.yml`), matching `**/qlpack.yml` with only its own
   `excludes: [/.codeql/]`. Our custom location was named `"CodeQL Pack
   Versions"` — a different name — so the config loader only *adds* its
   built-in default alongside ours instead of treating ours as an override
   (it only skips the default when a location with the exact same `name`
   already exists). The built-in default has no idea about our
   `ql/hotspots/` exclude, so it bumps that file regardless of what we
   configured.
2. **Our own location's pattern has never actually matched anything, ever.**
   `^version:\s*{version}$` anchors `^`/`$` to the whole file (not each
   line) without a `(?m)` multiline flag, and `version:` is never the
   literal first/last byte of a real multi-line `qlpack.yml`. All real
   bumping across every pack has silently been done by the built-in default
   this whole time — which is exactly why our exclude never took effect.

## Fix

Two one-line changes to `.release.yml`, verified together locally against
all 28 real `qlpack.yml` files in this repo (with their actual LF line
endings, matching what CI/the Linux Docker image actually sees):

- Rename our location to exactly `"CodeQL Packs"`, so `patch-release-me`'s
  default-merge logic skips adding its conflicting built-in default instead
  of running both.
- Add the `(?m)` flag so the anchor actually works per-line, keeping the
  original anti-partial-match protection (e.g. a bump of `0.2.2` incorrectly
  matching inside `0.2.20`) while actually working at all.

**Verified**: re-running `bump -m minor` against a real copy of this repo's
28 tracked `qlpack.yml` files (extracted via `git cat-file` to avoid a
Windows CRLF checkout artifact that produced a false negative on the first
attempt) - all 20 real packs bump `0.2.4 → 0.3.0` correctly,
`ql/hotspots/qlpack.yml` stays untouched, `.release.yml` itself still
bumps.

## Also in this PR

- Reverted `ql/hotspots/qlpack.yml`'s unintended version bump directly on
  #173 (separate commit there) to unblock that release without waiting on
  this fix.
- Documents the `"CodeQL Packs"` name + `(?m)` pattern requirements in
  `CONTRIBUTING.md`'s "Cutting a release" section, so a future edit doesn't
  silently reintroduce this.
