### PR TITLE
chore(ci): pre-install every CodeQL pack's dependencies in copilot-setup-steps.yml

### DIFF
--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -32,6 +32,37 @@ jobs:
         id: install-codeql
         uses: ./.github/actions/install-codeql
 
+      - name: Install CodeQL pack dependencies
+        run: |
+          # Pre-downloads every pack's dependencies (codeql/<lang>-all, etc.) into
+          # the pack download cache so Copilot never hits "Pack '...' was not
+          # found in the pack download cache. Run 'codeql pack install' to
+          # download the dependencies." when it runs `codeql query compile` /
+          # `codeql test run`.
+          #
+          # Without this, the agent has to discover on its own that `codeql pack
+          # install <dir>` is a prerequisite - which it does eventually, but not
+          # before burning several minutes on dead-end investigation first (e.g.
+          # a whole-filesystem `find / -name ...` looking for a "missing" library
+          # that was simply never installed). See the Copilot session on PR #173
+          # for a real example: it spent ~3 of its ~10 minutes on that rabbit
+          # hole before running `codeql pack install` and immediately finding/
+          # fixing the real one-line bug.
+          #
+          # We install every pack (not just the language the agent will end up
+          # touching) because we don't know ahead of time which one it'll be
+          # asked to fix - the extra cost is a few seconds per pack, which is
+          # trivial next to the minutes it can save. Same exclude list as
+          # update-codeql-version.yml's `codeql pack upgrade` loop: skip
+          # ql/hotspots (standalone tool, not a real GHCR-resolvable pack),
+          # codeql_home (vendored CLI packs), and codeql/ + */.codeql (the test-
+          # stubs clone below and CodeQL's own per-pack build caches).
+          for dir in $(find . -name qlpack.yml -not -path "./ql/hotspots/*" -not -path "./codeql_home/*" -not -path "./codeql/*" -not -path "*/.codeql/*" -exec dirname {} \;); do
+            echo "::group::codeql pack install $dir"
+            codeql pack install "$dir"
+            echo "::endgroup::"
+          done
+
       - name: Clone github/codeql (test stubs)
         env:
           GITHUB_TOKEN: ${{ github.token }}
@@ -48,9 +79,3 @@ jobs:
           # resolve, so `codeql test run` can actually compile the test snippets.
           # `--depth=1`: we only need the tree at that branch tip, not its history.
           gh repo clone github/codeql -- -b "codeql-cli-${CODEQL_CLI_VERSION}" --depth=1
-
-      # Deliberately not running `codeql pack install <lang>/...` here for every
-      # language - that's fast enough (a few seconds) for Copilot to run itself for
-      # whichever specific language pack(s) it's actually fixing, and running it
-      # for all 7 languages up front would just slow down every session regardless
-      # of what it's working on.

--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -23,6 +23,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
+      packages: read # matches ci.yml/update-codeql-version.yml's grant for `codeql pack install`/`upgrade` resolving codeql/* deps from GHCR
 
     steps:
       - name: Checkout


### PR DESCRIPTION
## Why

`copilot-setup-steps.yml` (added in #174) deliberately did **not** pre-run `codeql pack install` for any language, on the assumption it's "fast enough - a few seconds" for the Copilot coding agent to run itself when it needs it.

That assumption is true *once the agent knows to do it* - but a real delegated session on #173 (fixing the Python compile error caused by the CodeQL 2.22.4 bump) shows the **discovery cost dwarfs the install cost**:

1. Its first `codeql query compile --check-only "./python/"` failed with:
   ```
   ERROR: Pack 'codeql/python-all@4.0.13' was not found in the pack download cache. Run 'codeql pack install' to download the dependencies.
   ```
2. Instead of immediately reaching for `codeql pack install`, it spent **~3 of its ~10 total minutes** investigating why the library file was "missing" - checking `~/.codeql/packages/` (empty, since nothing was installed yet), then running a **whole-filesystem `find / -name "CryptoAlgorithmNames*"`** (35s) trying to locate it.
3. Only at turn 37 did it run `codeql pack install python/src/` (which took ~1.5s) - and immediately found + fixed the real one-line bug one turn later.

So roughly a third of the job was burned re-discovering a prerequisite step that a fixed setup step can just do once, up front, for free.

## What this changes

Adds an **"Install CodeQL pack dependencies"** step that pre-installs every pack's dependencies (`src`/`lib`/`ext`/`ext-library-sources`/`test`, across all 7 languages - 28 directories today) before the agent starts working.

- Reuses the exact `find qlpack.yml` + exclude pattern already established in `update-codeql-version.yml`'s `codeql pack upgrade` loop, for consistency:
  - excludes `ql/hotspots` (standalone tool, not a real GHCR-resolvable pack)
  - excludes `codeql_home` (vendored CLI packs)
  - excludes `codeql/` and `*/.codeql` (the test-stubs clone + CodeQL's own build caches)
- Installs **every** pack rather than guessing which language the agent will be asked to fix - the setup step can't know that ahead of time, and the per-pack install cost is only a couple seconds, trivial next to the minutes it can save.
- Removes the now-stale trailing comment explaining why pack install was deliberately skipped, since that's no longer the design.

## Verification

- `python -c "import yaml; yaml.safe_load(...)"` - YAML parses cleanly.
- Locally reproduced the `find`+exclude pattern against the real repo tree: correctly discovers all 28 real pack dirs (cpp/csharp/go/java/javascript/python/ruby × src/lib/ext/ext-library-sources/test as applicable) and correctly excludes `ql/hotspots`.
- This workflow only runs in Copilot's coding-agent environment (plus CI validation on changes to the file itself, per its `on:` triggers) - the real end-to-end test is the next delegated Copilot session that needs to compile/test a pack.

## Related

- #174 - added `copilot-setup-steps.yml` originally
- #173 - the real session this is based on (see its Copilot cloud agent job log for the full turn-by-turn trace)
