### PR TITLE
chore: bump all pack versions to 0.5.1

### DIFF
--- a/cpp/lib/qlpack.yml
+++ b/cpp/lib/qlpack.yml
@@ -1,5 +1,5 @@
 library: true 
 name: githubsecuritylab/codeql-cpp-libs
-version: 0.5.0
+version: 0.5.1
 dependencies:
   codeql/cpp-all: '8.0.0'

--- a/cpp/src/qlpack.yml
+++ b/cpp/src/qlpack.yml
@@ -1,6 +1,6 @@
 library: false
 name: githubsecuritylab/codeql-cpp-queries
-version: 0.5.0
+version: 0.5.1
 suites: suites
 defaultSuiteFile: suites/cpp.qls
 dependencies:

--- a/csharp/ext-library-sources/qlpack.yml
+++ b/csharp/ext-library-sources/qlpack.yml
@@ -1,6 +1,6 @@
 library: true
 name: githubsecuritylab/codeql-csharp-library-sources
-version: 0.5.0
+version: 0.5.1
 extensionTargets:
   codeql/csharp-all: '5.4.8'
 dataExtensions:

--- a/csharp/ext/qlpack.yml
+++ b/csharp/ext/qlpack.yml
@@ -1,6 +1,6 @@
 library: true
 name: githubsecuritylab/codeql-csharp-extensions
-version: 0.5.0
+version: 0.5.1
 extensionTargets:
   codeql/csharp-all: '5.4.8'
 dataExtensions:

--- a/csharp/lib/qlpack.yml
+++ b/csharp/lib/qlpack.yml
@@ -1,5 +1,5 @@
 library: true 
 name: githubsecuritylab/codeql-csharp-libs
-version: 0.5.0
+version: 0.5.1
 dependencies:
   codeql/csharp-all: "5.4.8"

--- a/csharp/src/qlpack.yml
+++ b/csharp/src/qlpack.yml
@@ -1,6 +1,6 @@
 library: false
 name: githubsecuritylab/codeql-csharp-queries
-version: 0.5.0
+version: 0.5.1
 suites: suites
 defaultSuiteFile: suites/csharp.qls
 dependencies:

--- a/go/ext/qlpack.yml
+++ b/go/ext/qlpack.yml
@@ -1,6 +1,6 @@
 library: true
 name: githubsecuritylab/codeql-go-extensions
-version: 0.5.0
+version: 0.5.1
 extensionTargets:
   codeql/go-all: '7.0.1'
 dataExtensions:

--- a/go/lib/qlpack.yml
+++ b/go/lib/qlpack.yml
@@ -1,5 +1,5 @@
 library: true 
 name: githubsecuritylab/codeql-go-libs
-version: 0.5.0
+version: 0.5.1
 dependencies:
   codeql/go-all: '7.0.1'

--- a/go/src/qlpack.yml
+++ b/go/src/qlpack.yml
@@ -1,6 +1,6 @@
 library: false
 name: githubsecuritylab/codeql-go-queries
-version: 0.5.0
+version: 0.5.1
 suites: suites
 defaultSuiteFile: suites/go.qls
 dependencies:

--- a/java/ext-library-sources/qlpack.yml
+++ b/java/ext-library-sources/qlpack.yml
@@ -1,6 +1,6 @@
 library: true
 name: githubsecuritylab/codeql-java-library-sources
-version: 0.5.0
+version: 0.5.1
 extensionTargets:
   codeql/java-all: '8.1.1'
 dataExtensions:

--- a/java/ext/qlpack.yml
+++ b/java/ext/qlpack.yml
@@ -1,6 +1,6 @@
 library: true
 name: githubsecuritylab/codeql-java-extensions
-version: 0.5.0
+version: 0.5.1
 extensionTargets:
   codeql/java-all: '8.1.1'
 dataExtensions:

--- a/java/lib/qlpack.yml
+++ b/java/lib/qlpack.yml
@@ -1,5 +1,5 @@
 library: true 
 name: githubsecuritylab/codeql-java-libs
-version: 0.5.0
+version: 0.5.1
 dependencies:
   codeql/java-all: '8.1.1'

--- a/java/src/qlpack.yml
+++ b/java/src/qlpack.yml
@@ -1,6 +1,6 @@
 library: false
 name: githubsecuritylab/codeql-java-queries
-version: 0.5.0
+version: 0.5.1
 suites: suites
 defaultSuiteFile: suites/java.qls
 dependencies:

--- a/javascript/lib/qlpack.yml
+++ b/javascript/lib/qlpack.yml
@@ -1,5 +1,5 @@
 library: true
 name: githubsecuritylab/codeql-javascript-libs
-version: 0.5.0
+version: 0.5.1
 dependencies:
   codeql/javascript-all: '2.6.23'

--- a/javascript/src/qlpack.yml
+++ b/javascript/src/qlpack.yml
@@ -1,6 +1,6 @@
 library: false
 name: githubsecuritylab/codeql-javascript-queries
-version: 0.5.0
+version: 0.5.1
 suites: suites
 defaultSuiteFile: suites/javascript.qls
 dependencies:

--- a/python/ext/qlpack.yml
+++ b/python/ext/qlpack.yml
@@ -1,6 +1,6 @@
 library: true
 name: githubsecuritylab/codeql-python-extensions
-version: 0.5.0
+version: 0.5.1
 extensionTargets:
   codeql/python-all: '7.0.0'
 dataExtensions:

--- a/python/lib/qlpack.yml
+++ b/python/lib/qlpack.yml
@@ -1,5 +1,5 @@
 library: true 
 name: githubsecuritylab/codeql-python-libs
-version: 0.5.0
+version: 0.5.1
 dependencies:
   codeql/python-all: '7.0.0'

--- a/python/src/qlpack.yml
+++ b/python/src/qlpack.yml
@@ -1,6 +1,6 @@
 library: false
 name: githubsecuritylab/codeql-python-queries
-version: 0.5.0
+version: 0.5.1
 suites: suites
 defaultSuiteFile: suites/python.qls
 dependencies:

--- a/ruby/lib/qlpack.yml
+++ b/ruby/lib/qlpack.yml
@@ -1,5 +1,5 @@
 library: true 
 name: githubsecuritylab/codeql-ruby-libs
-version: 0.5.0
+version: 0.5.1
 dependencies:
   codeql/ruby-all: '5.1.11'

--- a/ruby/src/qlpack.yml
+++ b/ruby/src/qlpack.yml
@@ -1,6 +1,6 @@
 library: false
 name: githubsecuritylab/codeql-ruby-queries
-version: 0.5.0
+version: 0.5.1
 suites: suites
 defaultSuiteFile: suites/ruby.qls
 dependencies:


### PR DESCRIPTION
## What
Bumps every language's `src`/`lib`/`ext`/`ext-library-sources` `qlpack.yml` `version:` field from `0.5.0` → `0.5.1` (20 files, `ql/hotspots/` and `*/test/` excluded, matching `.release.yml`'s own excludes).

## Why
`.release.yml` was already bumped to `0.5.1` and the [`v0.5.1` GitHub Release](https://github.com/GitHubSecurityLab/CodeQL-Community-Packs/releases/tag/v0.5.1) was already cut (via `update-release.yml`/PR #180), but **no pack's own `qlpack.yml` version was bumped to match**. `publish.yml` only publishes a pack when its local `qlpack.yml` version differs from what's currently on GHCR — since every pack was still at `0.5.0` locally, a manual `workflow_dispatch` of `publish.yml` correctly found nothing to publish. The `v0.5.1` release notes/changelog exist, but no package was ever actually shipped under that version.

Staying at `0.5.1` (rather than skipping to `0.5.2`) since nothing was ever actually published as `0.5.1` — this just makes the real packages catch up to the release that's already been cut.

## Follow-up (separate, not blocking this PR)
`.release.yml`'s custom `"CodeQL Packs"` location is *supposed* to auto-bump every `qlpack.yml`'s version via `patch-release-me` whenever `.release.yml` itself is bumped, but it silently didn't fire for this release (it did work for the prior `0.4.0`→`0.5.0` cut). Will investigate why as a separate follow-up so this manual catch-up step isn't needed on every future release.

## Next step after merge
Manually dispatch `publish.yml` (`workflow_dispatch`) to actually publish all packs at `0.5.1`.

Co-authored-by: Copilot App <223556219+Copilot@users.noreply.github.com>