### PR TITLE
Upgrade actions/cache from v4 to v6 (node 20 warning)

### DIFF
--- a/.github/actions/install-codeql/action.yml
+++ b/.github/actions/install-codeql/action.yml
@@ -21,7 +21,7 @@ runs:
 
     - name: Cache CodeQL
       id: cache-codeql
-      uses: actions/cache@v4
+      uses: actions/cache@v6
       with:
         # A list of files, directories, and wildcard patterns to cache and restore
         path: ${{github.workspace}}/codeql_home


### PR DESCRIPTION
This pull request updates the GitHub Actions workflow to use a newer version of the [cache action v6](https://github.com/actions/cache/releases/tag/v6)

Dependency update:

* Updated the `actions/cache` dependency from version `v4` to `v6` in `.github/actions/install-codeql/action.yml` to ensure compatibility and take advantage of improvements in the latest version.

Dependabot does not support updating composite actions: https://github.com/GitHubSecurityLab/CodeQL-Community-Packs/actions/runs/30304804445