### PR TITLE
Add Go/Python new extensions to synthetics configuration

### DIFF
--- a/configs/synthetics.yml
+++ b/configs/synthetics.yml
@@ -44,7 +44,9 @@ packs:
 
     # Data extensions via Community Packs https://github.com/GitHubSecurityLab/CodeQL-Community-Packs
     - githubsecuritylab/codeql-csharp-extensions
+    - githubsecuritylab/codeql-go-extensions
     - githubsecuritylab/codeql-java-extensions
+    - githubsecuritylab/codeql-python-extensions
 
     ### Trail of Bits ###
     # Queris via packs: https://github.com/trailofbits/codeql-queries  (default suites include security + crypto


### PR DESCRIPTION
This pull request updates the CodeQL configuration to include additional community packs for enhanced language support.

**CodeQL Community Pack additions:**

* Added `githubsecuritylab/codeql-go-extensions` to enable Go language data extensions in the CodeQL analysis.
* Added `githubsecuritylab/codeql-python-extensions` to enable Python language data extensions in the CodeQL analysis.


Follow up to: https://github.com/GitHubSecurityLab/CodeQL-Community-Packs/pull/144 
- publishing 0.7.1 with these extensions in it! - https://github.com/GitHubSecurityLab/CodeQL-Community-Packs/actions/runs/30327904170