### PR TITLE
fix: correct issue link in README Support section

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ This project is licensed under the terms of the MIT open source license. Please 
 
 ## Support
 
-Please [create GitHub issues](https://github.com/advanced-security/brew-dependency-submission-action) for any feature requests, bugs, or documentation problems.
+Please [create GitHub issues](https://github.com/GitHubSecurityLab/CodeQL-Community-Packs/issues) for any feature requests, bugs, or documentation problems.
 
 ## Contributing
 


### PR DESCRIPTION
## Description

This PR fixes an incorrect link in the README.md file's Support section.

## Problem

The Support section was linking to the wrong repository's issue tracker:
- **Incorrect**: https://github.com/advanced-security/brew-dependency-submission-action/issues
- **Correct**: https://github.com/GitHubSecurityLab/CodeQL-Community-Packs/issues

## Changes

- Updated the Support section link to point to the correct repository

## Testing

- Verified the link points to the correct issue tracker
- No functional code changes

## Note

This is a documentation-only fix that improves user experience by directing contributors to the correct issue tracker.

---

I apologize for any inconvenience caused by previous submissions. This is a focused, single-issue fix.

Local environment limitations: Documentation change only, no runtime testing required.

cc @GitHubSecurityLab maintainers