### PR TITLE
Fix publish summary showing "no result" for go/python ext-library-sources

### DIFF
--- a/.github/scripts/build-publish-summary.sh
+++ b/.github/scripts/build-publish-summary.sh
@@ -36,7 +36,12 @@ fi
 
 LANGUAGES=(cpp csharp go java javascript python ruby)
 TYPES=(src lib ext ext-library-sources)
+# Languages with an `ext` (model/extension) pack - matches the `extensions` job's matrix.
 EXT_LANGUAGES=(csharp go java python)
+# Languages with an `ext-library-sources` pack - matches the `library_sources_extensions`
+# job's matrix. This is a strict subset of EXT_LANGUAGES: go/python ship `ext` packs but
+# have no `ext-library-sources` pack, so they must not be expected to have a result for it.
+EXT_LIBRARY_SOURCES_LANGUAGES=(csharp java)
 
 lang_label() {
   case "$1" in
@@ -54,6 +59,14 @@ lang_label() {
 is_ext_language() {
   local lang="$1"
   for l in "${EXT_LANGUAGES[@]}"; do
+    [ "$l" == "$lang" ] && return 0
+  done
+  return 1
+}
+
+is_ext_library_sources_language() {
+  local lang="$1"
+  for l in "${EXT_LIBRARY_SOURCES_LANGUAGES[@]}"; do
     [ "$l" == "$lang" ] && return 0
   done
   return 1
@@ -146,7 +159,11 @@ echo "| --- | --- | --- | --- | --- |"
 for lang in "${LANGUAGES[@]}"; do
   row="| $(lang_label "$lang") |"
   for type in "${TYPES[@]}"; do
-    if { [ "$type" == "ext" ] || [ "$type" == "ext-library-sources" ]; } && ! is_ext_language "$lang"; then
+    if [ "$type" == "ext" ] && ! is_ext_language "$lang"; then
+      row="$row n/a |"
+      continue
+    fi
+    if [ "$type" == "ext-library-sources" ] && ! is_ext_library_sources_language "$lang"; then
       row="$row n/a |"
       continue
     fi


### PR DESCRIPTION
## Problem

PR #196 fixed the "❓ no result" bug affecting every cell in the publish summary table. However, as seen in the [v0.7.2 release notes](https://github.com/GitHubSecurityLab/CodeQL-Community-Packs/releases/tag/v0.7.2), Go and Python still show "❓ no result" specifically in the `Library sources (ext-library-sources)` column, instead of `n/a`.

## Root cause

`go` and `python` only ship an `ext` (model/extension) pack — they have no `ext-library-sources` pack at all (only `csharp`/`java` do, matching the `library_sources_extensions` job's `matrix.language: ["csharp", "java"]` in `publish.yml`).

`build-publish-summary.sh` reused a single `EXT_LANGUAGES=(csharp go java python)` list to decide "n/a" vs. "expect a result" for **both** the `ext` and `ext-library-sources` columns. Since `go`/`python` are in that list, the script incorrectly expected a publish-result fragment for their (nonexistent) `ext-library-sources` pack, and since none was ever produced, it rendered "❓ no result" instead of "n/a".

## Fix

Added a separate `EXT_LIBRARY_SOURCES_LANGUAGES=(csharp java)` list matching the `library_sources_extensions` job's actual matrix, and check each column against its own list.

## Verification

Ran the script locally (via WSL bash) against mock publish-result JSON fragments reproducing the v0.7.2 scenario (all `src`/`lib` published for every language, `ext` published for csharp/go/java/python, `ext-library-sources` published only for csharp/java). Confirmed the output now shows `n/a` for Go/Python's `ext-library-sources` column instead of "❓ no result", while csharp/java still render their download badges correctly.