### PR TITLE
docs(csharp): fix stale comment on codeql/csharp-queries dependency

### DIFF
--- a/csharp/src/qlpack.yml
+++ b/csharp/src/qlpack.yml
@@ -5,5 +5,5 @@ suites: suites
 defaultSuiteFile: suites/csharp.qls
 dependencies:
   codeql/csharp-all: "7.1.0"
-  codeql/csharp-queries: "1.8.0" # Required for Dependencies.ql
+  codeql/csharp-queries: "1.8.0" # Required by suites/csharp-audit.qls and suites/csharp-external-api.qls for upstream cs/untrusted-data-to-external-api
   githubsecuritylab/codeql-csharp-libs: "*"


### PR DESCRIPTION
## What
Fixes an inaccurate inline comment on the `codeql/csharp-queries` dependency in `csharp/src/qlpack.yml`.

## Why
The comment said this dependency was `# Required for Dependencies.ql`. That was true when it was added in 2023, but stopped being true in commit `8913c63` ("Fix various compilation issues", Jan 2025), which switched `csharp/src/audit/explore/Dependencies.ql`'s import from `Telemetry.ExternalApi` (a module that only lives in the `codeql/csharp-queries` pack) to `semmle.code.csharp.telemetry.ExternalApi` (which ships inside `codeql/csharp-all`). Nobody updated the comment (or checked whether the dependency itself could be dropped) at the time.

## Investigation
I initially assumed the dependency itself was now unused and could be removed (matching go/java/python/javascript/ruby, none of which depend on their `-queries` pack). That's wrong: `suites/csharp-audit.qls` and `suites/csharp-external-api.qls` both explicitly pull the upstream `cs/untrusted-data-to-external-api` query `from: codeql/csharp-queries` — that query only exists in the queries pack, not `-all`. Both suites are actively used (`configs/audit.yml`, `configs/synthetics.yml`), so the dependency must stay. This mirrors cpp's `codeql/cpp-queries` dependency, which pulls `cpp/untrusted-data-to-external-api` the same way (and cpp's `Dependencies.ql` still genuinely needs `Metrics.Dependencies.ExternalDependencies`, which is queries-pack-only upstream).

## Change
Only the comment changes, to correctly explain why the dependency is kept:
```diff
-  codeql/csharp-queries: "1.8.0" # Required for Dependencies.ql
+  codeql/csharp-queries: "1.8.0" # Required by suites/csharp-audit.qls and suites/csharp-external-api.qls for upstream cs/untrusted-data-to-external-api
```

No dependency versions, lock files, or query logic changed. Verified `csharp/src/audit/explore/Dependencies.ql` still compiles.

Co-authored-by: Copilot App <223556219+Copilot@users.noreply.github.com>
Copilot-Session: e78d3f00-2ea0-459b-86a2-91adc0e31c50