### PR TITLE
ci: simplify Patch Release Me 0.6.7 invocation

### DIFF
--- a/.github/workflows/update-codeql-version.yml
+++ b/.github/workflows/update-codeql-version.yml
@@ -136,29 +136,11 @@ jobs:
 
       - name: Bump release version (optional)
         if: steps.release_bump.outputs.bump != ''
-        run: |
-          set -euo pipefail
-          # Invoke the pinned patch-release-me image directly via `docker run`
-          # instead of `uses: 42ByteLabs/patch-release-me@...`. That action's own
-          # action.yml builds its Docker CMD as a single YAML list item
-          # (`-m "${{ inputs.mode }}"`); Docker container actions don't go
-          # through a shell, so the literal quote characters end up baked into
-          # ONE argv token (`-m "minor"`). clap can't match that against
-          # "patch"/"minor"/"major" and silently falls back to its own default
-          # (Patch) - meaning `minor`/`major` have always quietly produced a
-          # patch bump instead (confirmed via a local repro: see PR history).
-          # Running the same pinned image ourselves via a normal shell `run:`
-          # step naturally splits `-m` and the mode value into separate argv
-          # entries, avoiding the bug entirely.
-          #
-          # Pinned by digest (not just tag) so the exact image content can't
-          # change out from under us - digest corresponds to the 0.6.5 tag.
-          docker run --rm \
-            --user "$(id -u):$(id -g)" \
-            -v "${{ github.workspace }}:/repo" \
-            -w /repo \
-            ghcr.io/42bytelabs/patch-release-me@sha256:d9d7abe7051855d0c395fec99d931acc002fb6b299ca16b8123e2c8ef0c7e750 \
-            --disable-banner bump -m ${{ steps.release_bump.outputs.bump }}
+        # TODO: Return to the upstream action after its runtime image is digest-pinned:
+        # https://github.com/42ByteLabs/patch-release-me/issues/169
+        uses: docker://ghcr.io/42bytelabs/patch-release-me:0.6.7@sha256:b9624359ce08707dfb4d22bcbf9d1a75f7f4718ccec610ddaa62280ffea98958
+        with:
+          args: --disable-banner bump -m ${{ steps.release_bump.outputs.bump }}
 
       - name: Set release prerelease flag (optional)
         if: steps.release_bump.outputs.bump != ''

--- a/.github/workflows/update-release.yml
+++ b/.github/workflows/update-release.yml
@@ -36,28 +36,11 @@ jobs:
           private-key: ${{ secrets.SECLABS_APP_KEY }}
 
       - name: "Patch Release Me"
-        run: |
-          set -euo pipefail
-          # Invoke the pinned patch-release-me image directly via `docker run`
-          # instead of `uses: 42ByteLabs/patch-release-me@...`. That action's own
-          # action.yml builds its Docker CMD as a single YAML list item
-          # (`-m "${{ inputs.mode }}"`); Docker container actions don't go
-          # through a shell, so the literal quote characters end up baked into
-          # ONE argv token (`-m "minor"`). clap can't match that against
-          # "patch"/"minor"/"major" and silently falls back to its own default
-          # (Patch) - meaning `minor`/`major` have always quietly produced a
-          # patch bump instead (confirmed via a local repro: see PR history).
-          # Running the same pinned image ourselves via a normal shell `run:`
-          # step naturally splits `-m` and the mode value into separate argv
-          # entries, avoiding the bug entirely.
-          # Pinned by digest (not just tag) so the exact image content can't
-          # change out from under us - digest corresponds to the 0.6.5 tag.
-          docker run --rm \
-            --user "$(id -u):$(id -g)" \
-            -v "${{ github.workspace }}:/repo" \
-            -w /repo \
-            ghcr.io/42bytelabs/patch-release-me@sha256:d9d7abe7051855d0c395fec99d931acc002fb6b299ca16b8123e2c8ef0c7e750 \
-            --disable-banner bump -m ${{ inputs.mode }}
+        # TODO: Return to the upstream action after its runtime image is digest-pinned:
+        # https://github.com/42ByteLabs/patch-release-me/issues/169
+        uses: docker://ghcr.io/42bytelabs/patch-release-me:0.6.7@sha256:b9624359ce08707dfb4d22bcbf9d1a75f7f4718ccec610ddaa62280ffea98958
+        with:
+          args: --disable-banner bump -m ${{ inputs.mode }}
 
       - name: Determine new release version
         id: release_version


### PR DESCRIPTION
## Summary

- Replace both manual Patch Release Me `docker run` workarounds with GitHub's native Docker action syntax.
- Upgrade from the 0.6.5 image to 0.6.7 and pin the OCI image-index digest.
- Remove manual user, workspace mount, and working-directory plumbing.
- Retain the prerelease-field restoration because Patch Release Me still drops unknown configuration keys.
- Document returning to the repository action after 42ByteLabs/patch-release-me#169 is resolved.

## Why

Patch Release Me 0.6.7 fixes the mode argument handling and has a published container image. Calling the image through `docker://...:0.6.7@sha256:...` preserves immutable execution while allowing GitHub Actions to manage the workspace and arguments.

The repository action is not used yet because its Dockerfile still references a mutable image tag.

## Validation

- Parsed both updated workflows as YAML.
- Ran `git diff --check`.
- Resolved the 0.6.7 OCI image-index digest with `docker buildx imagetools inspect`.
